### PR TITLE
Add fallback for missing heightmap

### DIFF
--- a/js/terrain.js
+++ b/js/terrain.js
@@ -28,6 +28,13 @@ export function loadHeightmap(mapSeed, onReady) {
     noise = new SimplexNoise(mapSeed);
     if (onReady) onReady();
   };
+  hmImg.onerror = () => {
+    console.warn('Failed to load heightmap.png. Using flat fallback heightmap.');
+    mapW = mapH = 1;
+    mapData = new Float32Array([0]);
+    noise = new SimplexNoise(mapSeed);
+    if (onReady) onReady();
+  };
 }
 
 function getHeight(u,v){


### PR DESCRIPTION
## Summary
- make scene setup resilient to a missing heightmap

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855fd75acb88326afb8253f0f4d3458