### PR TITLE
Implement named players with HUD messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@
     <ol id="leaderboard-list"></ol>
   </div>
 
+  <div id="name-layer"></div>
+  <div id="hud"></div>
+
   <button id="fullscreen-btn">⛶</button>
   <canvas id="minimap"></canvas>
   <div id="joystick-zone"></div>

--- a/js/game.js
+++ b/js/game.js
@@ -1,11 +1,13 @@
 // js/game.js - orchestrates game modules
 import { loadHeightmap, initTerrain, terrain, meshHeightAt, HALF, GRID, SPAN, sampleHybridNormal, hmImg, deformTerrain } from './terrain.js';
 import { initCharacter, character, headMesh, bodyMesh, Larm, Rarm, Lleg, Rleg, boxGeo, octGeo, projectiles, spawnLoadedBullet, catchBoomerang, loadedBullet, setAim, teleport } from './character.js';
-import { setupNetwork, sendInput, sendState, socket, myId, activeTarget } from './network.js';
+import { setupNetwork, sendInput, sendState, socket, myId, activeTarget, setMyName, names, ghosts } from './network.js';
 import { setupInput, move } from './input.js';
 
 export function startGame(){
   const mapSeed = '🌎';
+  const userName = prompt('Enter your name:', 'Player') || 'Player';
+  setMyName(userName);
   const scene   = new THREE.Scene();
   let skyMesh;
   const camera  = new THREE.PerspectiveCamera(75, innerWidth/innerHeight, 0.1, 500);
@@ -21,6 +23,9 @@ export function startGame(){
   renderer.setPixelRatio(Math.min(devicePixelRatio,1));
   renderer.setSize(innerWidth, innerHeight);
   document.body.appendChild(renderer.domElement);
+
+  const labelLayer = document.getElementById('name-layer');
+  const nameLabels = new Map();
 
   const miniCanvas = document.getElementById('minimap');
   const miniCtx    = miniCanvas.getContext('2d');
@@ -199,6 +204,29 @@ export function startGame(){
       );
       camera.position.copy(character.position).add(camOff);
       camera.lookAt(character.position);
+
+      const allPlayers = new Map([[myId, character], ...ghosts.entries()]);
+      allPlayers.forEach((obj,id)=>{
+        let label = nameLabels.get(id);
+        if(!label){
+          label = document.createElement('div');
+          label.className = 'name-label';
+          labelLayer.appendChild(label);
+          nameLabels.set(id,label);
+        }
+        label.textContent = names.get(id) || (id===myId?userName:id);
+        const pos = obj.position.clone();
+        pos.y += 3.5;
+        pos.project(camera);
+        const x = (pos.x * 0.5 + 0.5) * innerWidth;
+        const y = (-pos.y * 0.5 + 0.5) * innerHeight;
+        label.style.transform = `translate(-50%,-50%) translate(${x}px,${y}px)`;
+        label.style.display = obj.visible===false ? 'none' : 'block';
+      });
+      // remove labels for departed players
+      nameLabels.forEach((el,id)=>{
+        if(!allPlayers.has(id)) { el.remove(); nameLabels.delete(id); }
+      });
 
       if(socket.readyState===1 && myId){
         sendState({ x:character.position.x, y:character.position.y, z:character.position.z,

--- a/js/network.js
+++ b/js/network.js
@@ -11,6 +11,8 @@ export const remoteShots = new Map();
 export let myId = null;
 export let myColor = new THREE.Color(0x222222);
 export const scores = new Map();
+export const names  = new Map();
+export let myName = '';
 export let activeTarget = null;
 
 export function sendInput(input){
@@ -25,6 +27,22 @@ export function sendState(state){
   }
 }
 
+export function setMyName(name){
+  myName = name;
+  if(myId && socket.readyState===1){
+    socket.send(JSON.stringify({ t:'setName', name }));
+  }
+}
+
+export function showHudMessage(text){
+  const hud = document.getElementById('hud');
+  if(!hud) return;
+  hud.textContent = text;
+  hud.style.opacity = '1';
+  clearTimeout(showHudMessage._to);
+  showHudMessage._to = setTimeout(()=>{ hud.style.opacity='0'; },2000);
+}
+
 export function updateScoreboard() {
   const ol = document.getElementById('leaderboard-list');
   ol.innerHTML = '';
@@ -32,7 +50,8 @@ export function updateScoreboard() {
     .sort((a,b) => b[1] - a[1])
     .forEach(([id, pts]) => {
       const li = document.createElement('li');
-      li.textContent = (id === myId ? 'You' : id) + ': ' + pts;
+      const name = id === myId ? (myName || 'You') : (names.get(id) || id);
+      li.textContent = name + ': ' + pts;
       ol.appendChild(li);
     });
 }
@@ -40,6 +59,7 @@ export function updateScoreboard() {
 export function applySnapshot({ players:pack, projectiles:shots }, scene, bulletGeo){
   Object.keys(pack).forEach(id => {
     if (!scores.has(id)) scores.set(id, 0);
+    if (pack[id].name) names.set(id, pack[id].name);
   });
   updateScoreboard();
 
@@ -118,12 +138,23 @@ export function setupNetwork(scene, bulletGeo, targetHandlers){
       case 'scoreUpdate': {
         Object.entries(msg.scores).forEach(([id, pts]) => { scores.set(id, pts); });
         updateScoreboard();
+        if(msg.scorer){
+          const name = msg.scorer === myId ? (myName||'You') : (names.get(msg.scorer) || msg.scorer);
+          const pts  = scores.get(msg.scorer) || 0;
+          showHudMessage(`${name} has ${pts} point${pts===1?'':'s'}`);
+        }
         break;
       }
       case 'welcome':
         myId    = msg.id;
         myColor = new THREE.Color().setStyle(msg.color);
         scores.set(myId, 0);
+        names.set(myId, myName);
+        if(socket.readyState===1) socket.send(JSON.stringify({ t:'setName', name: myName }));
+        updateScoreboard();
+        break;
+      case 'nameUpdate':
+        names.set(msg.id, msg.name);
         updateScoreboard();
         break;
       case 'snapshot':

--- a/server.js
+++ b/server.js
@@ -55,11 +55,11 @@ function pickNamedColour() {
 function packSnapshot() {
   return JSON.stringify({
     t: 'snapshot',
-    // players: id → { x,y,z,yaw,pitch,flyMode,color,score }
+    // players: id → { x,y,z,yaw,pitch,flyMode,color,score,name }
     players: Object.fromEntries(
       [...players.entries()].map(([id,p]) => [
         id,
-        { ...p.state, color: p.color, score: p.score || 0 }
+        { ...p.state, color: p.color, score: p.score || 0, name: p.name || '' }
       ])
     ),
     // array of projectile records
@@ -89,7 +89,7 @@ wss.on('connection', ws => {
   const color = pickNamedColour();
 
   // Initialize player state + score
-  players.set(id, { input:{}, state:{}, color, score: 0 });
+  players.set(id, { input:{}, state:{}, color, score: 0, name: '' });
   scores.set(id, 0);
 
   // Send welcome packet with assigned ID, color, and noise seed
@@ -111,6 +111,15 @@ wss.on('connection', ws => {
       case 'state':
         players.get(id).state = msg.state;
         break;
+
+      // Player provides their display name
+      case 'setName': {
+        const p = players.get(id);
+        if (p) p.name = msg.name.substring(0,20);
+        const nameMsg = JSON.stringify({ t:'nameUpdate', id, name:p.name });
+        wss.clients.forEach(c => c.readyState===1 && c.send(nameMsg));
+        break;
+      }
 
       // A new boomerang shot fired
       case 'shot': {
@@ -150,7 +159,8 @@ wss.on('connection', ws => {
           // Broadcast full scoreboard to all clients
           const scoreMsg = JSON.stringify({
             t: 'scoreUpdate',
-            scores: Object.fromEntries(scores)
+            scores: Object.fromEntries(scores),
+            scorer: id
           });
           wss.clients.forEach(c =>
             c.readyState===1 && c.send(scoreMsg)

--- a/styles/style.css
+++ b/styles/style.css
@@ -141,3 +141,37 @@ body {
   border-width: 12px 10px 0 10px;
   border-color: white transparent transparent transparent;
 }
+
+/* Player name labels */
+#name-layer {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  z-index: 120;
+}
+.name-label {
+  position: absolute;
+  color: #fff;
+  font-family: sans-serif;
+  font-size: 12px;
+  text-shadow: 0 0 3px #000;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+/* HUD message */
+#hud {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  padding: 6px 12px;
+  font-family: sans-serif;
+  border-radius: 4px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+  z-index: 200;
+}


### PR DESCRIPTION
## Summary
- prompt for player name at startup
- send name to server and broadcast name updates
- display player names in leaderboard and above avatars
- show HUD notification when someone scores

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_68563d20ba5c83269fe9319550dd6b03