### PR TITLE
Fix scoreboard sync

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -506,7 +506,13 @@ function makeRemoteAvatar(col){
       scores.set(id, 0);
     }
   });
-  // Now update the DOM
+
+  for (const id of [...scores.keys()]) {
+    if (!(id in pack)) {
+      scores.delete(id);
+    }
+  }
+
   updateScoreboard();
  
   /* ---------- players ---------- */


### PR DESCRIPTION
## Summary
- clean up `scores` map when processing snapshots so departed players don't linger

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68564c0380cc8326a9d582703bb9ce58