### PR TITLE
Improve texture quality with anisotropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+This project renders a deformable landscape in WebGL.
+
+### Graphics Enhancement
+
+Textures now use the maximum supported anisotropy value for crisper detail at glancing angles.

--- a/js/main.js
+++ b/js/main.js
@@ -328,6 +328,9 @@ function initTerrain(){
   const diffuseMap = textureLoader.load('assets/ruggeddiffused.png');
 
   const overlayMap = textureLoader.load('assets/ruggedpeaks.jpg');
+  const maxAnisotropy = renderer.capabilities.getMaxAnisotropy();
+  diffuseMap.anisotropy = maxAnisotropy;
+  overlayMap.anisotropy = maxAnisotropy;
   overlayMap.wrapS = overlayMap.wrapT = THREE.RepeatWrapping;
   overlayMap.repeat.set(GRID * SPAN / 256, GRID * SPAN / 256);
   geo.setAttribute('uv2', new THREE.BufferAttribute(geo.attributes.uv.array, 2));


### PR DESCRIPTION
## Summary
- apply maximum anisotropy to the diffuse and overlay textures
- document anisotropy improvement in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68564e2fe8388326afdce65162331794