### PR TITLE
Hide leaderboard when player is active

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -222,12 +222,17 @@ miniCanvas.width = MM_SIZE; miniCanvas.height = MM_SIZE;
 
 /* simple “idle controls” overlay fade */
 const infoEl     = document.getElementById('info');
+const leaderboardEl = document.getElementById('leaderboard');
 let   showTimer  = null;
 ['mousemove','mousedown','keydown','touchstart'].forEach(evt =>
   document.addEventListener(evt, () => {
     infoEl.style.opacity = '0';
+    leaderboardEl.style.opacity = '0';
     clearTimeout(showTimer);
-    showTimer = setTimeout(() => infoEl.style.opacity = '1', 10000);
+    showTimer = setTimeout(() => {
+      infoEl.style.opacity = '1';
+      leaderboardEl.style.opacity = '1';
+    }, 10000);
   }, { passive:true })
 );
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -59,6 +59,8 @@ canvas:not(#minimap) {
   border-radius: 4px;
   pointer-events: none;
   z-index: 150;
+  opacity: 1;
+  transition: opacity 0.8s ease;
 }
 #leaderboard-list {
   margin: 4px 0 0 16px;


### PR DESCRIPTION
## Summary
- fade leaderboard out on user activity and show it again after a delay
- add opacity transition styles for the leaderboard

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_6856564e34e88326959b13ab95d99e10