### PR TITLE
Replace minimap with directional HUD arrow

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
   </div>
 
   <button id="fullscreen-btn">⛶</button>
-  <canvas id="minimap"></canvas>
+  <div id="target-arrow"></div>
   <div id="joystick-zone"></div>
   <div id="joystick-look-zone"></div>
   <div id="shoot-button"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -224,11 +224,8 @@ renderer.setSize(innerWidth, innerHeight);
 document.body.appendChild(renderer.domElement);
   if (isMobile) setupMobileControls();
 
-/* minimap canvas */
-const miniCanvas = document.getElementById('minimap');
-const miniCtx    = miniCanvas.getContext('2d');
-const MM_SIZE = 200;
-miniCanvas.width = MM_SIZE; miniCanvas.height = MM_SIZE;
+/* HUD arrow */
+const arrowEl = document.getElementById('target-arrow');
 
 /* simple “idle controls” overlay fade */
 const infoEl     = document.getElementById('info');
@@ -830,34 +827,15 @@ function animate(now){
 
   renderer.render(scene,camera);
 
-  /* minimap */
-  miniCtx.clearRect(0,0,MM_SIZE,MM_SIZE);
-  miniCtx.globalAlpha=0.4;
-  miniCtx.drawImage(hmImg,0,0,MM_SIZE,MM_SIZE);
-  miniCtx.globalAlpha=1;
-  const xN=(character.position.x+HALF)/(GRID*SPAN);
-  const zN=(character.position.z+HALF)/(GRID*SPAN);
-  const px=xN*MM_SIZE, py=(1-zN)*MM_SIZE;
-  miniCtx.fillStyle='#f00';
-  miniCtx.beginPath(); miniCtx.arc(px,py,5,0,Math.PI*2); miniCtx.fill();
-  miniCtx.fillStyle='#fff'; miniCtx.fillRect(px-5,py-5,10,10);
-  miniCtx.save(); miniCtx.globalAlpha=0.2;
-  miniCtx.fillStyle='#fff';
-  miniCtx.beginPath();
-  miniCtx.moveTo(MM_SIZE/2,8);
-  miniCtx.lineTo(MM_SIZE/2+6,22);
-  miniCtx.lineTo(MM_SIZE/2-6,22);
-  miniCtx.closePath(); miniCtx.fill();
-  miniCtx.font='12px sans-serif'; miniCtx.textAlign='center';
-  miniCtx.fillText('N',MM_SIZE/2,36); miniCtx.restore();
-    // draw the active target on the minimap
+  /* guide arrow */
   if (activeTarget) {
-    const tx = (activeTarget.x + HALF) / (GRID * SPAN) * MM_SIZE;
-    const tz = (1 - (activeTarget.z + HALF) / (GRID * SPAN)) * MM_SIZE;
-    miniCtx.fillStyle = '#ff0';            // yellow
-    miniCtx.beginPath();
-    miniCtx.arc(tx, tz, 6, 0, Math.PI * 2);
-    miniCtx.fill();
+    const dx = activeTarget.x - character.position.x;
+    const dz = activeTarget.z - character.position.z;
+    const ang = Math.atan2(dx, dz) - yaw;
+    arrowEl.style.display = 'block';
+    arrowEl.style.transform = `translateX(-50%) rotate(${ang}rad)`;
+  } else {
+    arrowEl.style.display = 'none';
   }
 
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -11,7 +11,7 @@ html, body {
 }
 
 /* main WebGL canvas */
-canvas:not(#minimap) {
+canvas {
   width: 100%;
   height: 100%;
   display: block;
@@ -37,14 +37,20 @@ canvas:not(#minimap) {
   opacity: 1 !important;
 }
 
-/* Minimap in corner */
-#minimap {
+/* Arrow guiding to target */
+#target-arrow {
   position: absolute;
-  bottom: 10px; right: 10px;
-  width: 200px; height: 200px;
-  border: 2px solid #888;
-  background: rgba(0,0,0,0.5);
+  top: 50px;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-left: 12px solid transparent;
+  border-right: 12px solid transparent;
+  border-bottom: 20px solid yellow;
+  transform: translateX(-50%) rotate(0deg);
   pointer-events: none;
+  z-index: 110;
+  display: none;
 }
 
 /* Leaderboard styling */


### PR DESCRIPTION
## Summary
- remove minimap canvas and styling
- add HUD arrow to guide the player towards the current target
- rotate arrow in the animation loop based on player orientation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68565c5f58ac8326b8fc13f495ac6822