### PR TITLE
Add elevation-aware target arrow

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -831,9 +831,12 @@ function animate(now){
   if (activeTarget) {
     const dx = activeTarget.x - character.position.x;
     const dz = activeTarget.z - character.position.z;
+    const dy = (targetMesh ? targetMesh.position.y : 0) - character.position.y;
     const ang = Math.atan2(dx, dz) - yaw;
+    const vertAng = Math.atan2(dy, Math.hypot(dx, dz));
     arrowEl.style.display = 'block';
-    arrowEl.style.transform = `translateX(-50%) rotate(${ang}rad)`;
+    arrowEl.style.transform =
+        `translateX(-50%) rotateZ(${ang}rad) rotateX(${vertAng}rad)`;
   } else {
     arrowEl.style.display = 'none';
   }

--- a/styles/style.css
+++ b/styles/style.css
@@ -46,6 +46,8 @@ canvas {
   height: 24px;
   transform: translateX(-50%) rotate(0deg);
   transform-origin: 50% 100%;
+  transform-style: preserve-3d;
+  perspective: 800px;
   pointer-events: none;
   z-index: 110;
   display: none;


### PR DESCRIPTION
## Summary
- calculate vertical offset to target in `main.js`
- rotate guide arrow on X axis based on elevation difference
- enable 3-D transforms on `#target-arrow`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68566055b46c8326bff17cbb57eea22a