### PR TITLE
Directional path via tapered strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ Textures now use the maximum supported anisotropy value for crisper detail at gl
 - The on-screen arrow guiding to targets has been replaced by an in-world
   GPS-style path that dynamically updates.
 - That path now forms a directional ribbon with a color gradient so you can
-  immediately tell which way to head.
-- Arrow markers are spaced along that strip to reinforce the direction of travel.
+  immediately tell which way to head. The ribbon tapers from thick near you to
+  thin at the target, removing the need for extra arrow markers.

--- a/js/main.js
+++ b/js/main.js
@@ -226,11 +226,6 @@ document.body.appendChild(renderer.domElement);
 
 /* GPS path mesh */
 let pathMesh = null;
-const ARROW_SPACING = 8;
-const arrowGeom = new THREE.ConeGeometry(0.3, 0.8, 8);
-arrowGeom.rotateX(Math.PI / 2);
-const arrowMat  = new THREE.MeshBasicMaterial({ color: 0xffffff });
-let pathArrows = [];
 
 /* simple “idle controls” overlay fade */
 const infoEl     = document.getElementById('info');
@@ -306,7 +301,6 @@ case 'scoreUpdate': {
       pathMesh.geometry.dispose();
       pathMesh.material.dispose();
       pathMesh = null;
-      removePathArrows();
     }
     updatePathMesh();
     break;
@@ -737,7 +731,6 @@ function animate(now){
           pathMesh.geometry.dispose();
           pathMesh.material.dispose();
           pathMesh = null;
-          removePathArrows();
         }
       }
     }
@@ -859,7 +852,8 @@ window.addEventListener('resize',()=>{
   renderer.setSize(innerWidth,innerHeight);
 });
 
-function createPathStrip(from, to, width = 1, segments = 60, startCol, endCol) {
+function createPathStrip(from, to, startWidth = 1, endWidth = 0.5,
+                         segments = 60, startCol, endCol) {
   const dx = to.x - from.x;
   const dz = to.z - from.z;
   const len = Math.hypot(dx, dz) || 1;
@@ -874,6 +868,7 @@ function createPathStrip(from, to, width = 1, segments = 60, startCol, endCol) {
     const x = THREE.MathUtils.lerp(from.x, to.x, t);
     const z = THREE.MathUtils.lerp(from.z, to.z, t);
     const y = meshHeightAt(x, z) + 0.05;
+    const width = THREE.MathUtils.lerp(startWidth, endWidth, t);
     const offX = nx * width * 0.5;
     const offZ = nz * width * 0.5;
 
@@ -914,13 +909,13 @@ function updatePathMesh() {
   const start = character.position.clone();
   const endY = meshHeightAt(activeTarget.x, activeTarget.z) + 0.05;
   const end = new THREE.Vector3(activeTarget.x, endY, activeTarget.z);
-  const geo = createPathStrip(start, end, 1, 80, myColor, new THREE.Color(0xffff00));
+  const geo = createPathStrip(start, end, 1.5, 0.4, 80,
+                              myColor, new THREE.Color(0xffff00));
   if (pathMesh) {
     scene.remove(pathMesh);
     pathMesh.geometry.dispose();
     pathMesh.material.dispose();
   }
-  removePathArrows();
   pathMesh = new THREE.Mesh(
     geo,
     new THREE.MeshBasicMaterial({
@@ -930,31 +925,7 @@ function updatePathMesh() {
   );
   scene.add(pathMesh);
 
-  // add arrowheads along the strip
-  const dir = new THREE.Vector3().subVectors(end, start);
-  const len = dir.length();
-  if (len > 0) {
-    dir.set(dir.x, 0, dir.z).normalize();
-    const count = Math.floor(len / ARROW_SPACING);
-    for (let i = 1; i <= count; i++) {
-      const pos = start.clone().addScaledVector(dir, i * ARROW_SPACING);
-      pos.y = meshHeightAt(pos.x, pos.z) + 0.1;
-      const arrow = new THREE.Mesh(arrowGeom, arrowMat);
-      arrow.position.copy(pos);
-      arrow.rotation.y = Math.atan2(dir.x, dir.z);
-      scene.add(arrow);
-      pathArrows.push(arrow);
-    }
-  }
-}
-
-function removePathArrows() {
-  for (const a of pathArrows) {
-    scene.remove(a);
-    a.geometry.dispose();
-    a.material.dispose();
-  }
-  pathArrows.length = 0;
+  // path thickness tapers toward the destination – no arrows needed
 }
 
 /* ─────────────────────────── HELPERS ─────────────────────────────── */


### PR DESCRIPTION
## Summary
- drop arrow markers along GPS path
- gradually taper the path width from start to end
- update README description

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68566930ac648326ae2e19874e046b41