### PR TITLE
Automate tile baking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Run `./bake_tiles.py --min -1 -1 --max 1 1 --out tiles` to generate OBJ
 files for tiles within the given coordinate range. Start the HTTP server
 with `./tile_server.js` and your client can fetch `chunk_x_z.obj` files on
 demand.
+
+Alternatively, run `start-sig.ps1` to automatically bake the tiles and start all servers.

--- a/start-sig.ps1
+++ b/start-sig.ps1
@@ -1,12 +1,25 @@
-# Start both services in background and print LAN IP with links
+# Bake terrain tiles and start services
 
 $staticPort = 8080
 $wsPort     = 3000
+$tilePort   = 8081
 $ip = (Get-NetIPAddress -AddressFamily IPv4 | Where-Object {
-    $_.IPAddress -notmatch '^169\.|127\.' })[0].IPAddress
+    $_.IPAddress -notmatch '^169\.|127\.'
+}).IPAddress
+
+if (-not (Test-Path 'tiles')) {
+    New-Item -ItemType Directory -Path 'tiles' | Out-Null
+}
+$tileFiles = Get-ChildItem 'tiles' -Filter '*.obj' -ErrorAction SilentlyContinue
+if ($tileFiles.Count -eq 0) {
+    Write-Host 'Baking terrain tiles...'
+    python bake_tiles.py --min -1 -1 --max 1 1 --out tiles
+}
 
 Start-Process powershell -ArgumentList 'node', 'server.js' -NoNewWindow
 Start-Process powershell -ArgumentList 'npx live-server --port=8080 --host=0.0.0.0 --no-browser' -NoNewWindow
+Start-Process powershell -ArgumentList 'node', 'tile_server.js' -NoNewWindow
 
 Write-Host "Site running at   : http://${ip}:${staticPort}"
 Write-Host "WebSocket server  : ws://${ip}:${wsPort}"
+Write-Host "Tile server      : http://${ip}:${tilePort}/"


### PR DESCRIPTION
## Summary
- bake tiles automatically in `start-sig.ps1` and start the tile server
- document the new helper script in the README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68566eb2af948326813fefed5b73b2fe