### PR TITLE
Fix global three.js imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,15 +46,7 @@
   <div id="down-button"></div>
   <div id="sprint-button"></div>
 
-  <!-- Three.js & Noise libs -->
-  <script type="module">
-    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.module.js';
-    import { OBJLoader } from 'https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/loaders/OBJLoader.js';
-    import SimplexNoise from 'https://cdn.jsdelivr.net/npm/simplex-noise@3.0.0/dist/esm/simplex-noise.js';
-    window.THREE = THREE;
-    window.OBJLoader = OBJLoader;
-    window.SimplexNoise = SimplexNoise;
-  </script>
+  <!-- Three.js & Noise libs are imported by js/main.js -->
 
   <!-- Mobile UI behavior (joystick, fullscreen hints, fly/jump) -->
   <script>

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,8 @@
 // js/main.js
-// (Three & SimplexNoise must be exposed as globals in <script type="module">)
+// Import required libraries directly so we don't rely on globals
+import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.module.js';
+import { OBJLoader } from 'https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/loaders/OBJLoader.js';
+import SimplexNoise from 'https://cdn.jsdelivr.net/npm/simplex-noise@3.0.0/dist/esm/simplex-noise.js';
 
 window.onload = () => {
 


### PR DESCRIPTION
## Summary
- import `three.js`, `OBJLoader`, and `simplex-noise` directly in the main module
- remove the inline script in `index.html` that previously set up globals

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6856729b15548326889f79cbef0cb740