### PR TITLE
Fix FlyControls import

### DIFF
--- a/vendor/controls/FlyControls.js
+++ b/vendor/controls/FlyControls.js
@@ -1,8 +1,8 @@
 import {
-	EventDispatcher,
-	Quaternion,
-	Vector3
-} from 'three';
+        EventDispatcher,
+        Quaternion,
+        Vector3
+} from 'https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.module.js';
 
 const _changeEvent = { type: 'change' };
 


### PR DESCRIPTION
## Summary
- update FlyControls.js to use CDN path for the Three.js module

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856742d73948326a0093fa1c59117eb