### PR TITLE
Fix terrain load order and enable CORS

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -324,9 +324,10 @@ case 'scoreUpdate': {
 
 /* ─────────────────────────── TERRAIN LOAD ────────────────────────── */
 noise = new SimplexNoise(mapSeed);
-initTerrain();
-initCharacter();
-requestAnimationFrame(animate);
+initTerrain().then(() => {
+  initCharacter();
+  requestAnimationFrame(animate);
+});
 
 /* ───────────────────────────── TERRAIN ───────────────────────────── */
 function getNoise(u,v){
@@ -354,6 +355,7 @@ function loadTile(cx, cz){
 }
 
 function initTerrain(){
+  return new Promise(res => {
   const textureLoader = new THREE.TextureLoader();
   const diffuseMap = textureLoader.load('assets/ruggeddiffused.png');
   const overlayMap = textureLoader.load('assets/ruggedpeaks.jpg');
@@ -375,6 +377,8 @@ function initTerrain(){
     terrain = mesh;
     terrain.material = mat;
     scene.add(terrain);
+    res();
+  });
   });
 }
 function deformTerrain(impact,radius,depth){
@@ -391,6 +395,7 @@ function deformTerrain(impact,radius,depth){
   terrain.geometry.computeVertexNormals();
 }
 function meshHeightAt(x,z){
+  if (!terrain) return 0;
   const size=GRID*SPAN;
   const gx=Math.round((x+size/2)/SPAN);
   const gz=Math.round((z+size/2)/SPAN);

--- a/tile_server.js
+++ b/tile_server.js
@@ -7,6 +7,9 @@ const PORT = 8081;
 const ROOT = process.argv[2] || 'tiles';
 
 const server = http.createServer((req, res) => {
+  // Allow cross-origin requests so the main page can fetch tiles
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET');
   const urlPath = req.url.replace(/^\/+/, '');
   const filePath = path.join(ROOT, urlPath);
   fs.readFile(filePath, (err, data) => {


### PR DESCRIPTION
## Summary
- enable CORS headers in the tile server
- wait for the terrain to load before initializing the character
- guard `meshHeightAt` for missing terrain

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68567978f2048326b4c7202007d97860