### PR TITLE
Update mobile controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
       Joystick (left) → Move<br>
       Drag screen → Look<br>
       Red Button → Shoot<br>
-      ↑↓ → Jump / Fly<br>
-      Hold ⏩ → Run<br>
+      Tap top ↔ Jump / Ascend<br>
+      Tap bottom ↔ Descend<br>
       ⛶ → Fullscreen
     </span>
   </div>
@@ -42,9 +42,6 @@
   <div id="joystick-zone"></div>
   <div id="joystick-look-zone"></div>
   <div id="shoot-button"></div>
-  <div id="up-button"></div>
-  <div id="down-button"></div>
-  <div id="sprint-button"></div>
 
   <!-- Three.js & Noise libs are imported by js/main.js -->
 
@@ -53,11 +50,7 @@
     const isMobile      = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
     const infoPanel     = document.getElementById('info');
     const fullscreenBtn = document.getElementById('fullscreen-btn');
-    const upBtn         = document.getElementById('up-button');
-    const downBtn       = document.getElementById('down-button');
-    const sprintBtn     = document.getElementById('sprint-button');
-
-    let lastTapUp = 0, lastTapDown = 0, idleTimeout;
+    let idleTimeout;
 
     function resetIdleTimer() {
       infoPanel.classList.remove('visible');
@@ -77,8 +70,6 @@
       document.getElementById('joystick-zone').style.display      = 'block';
       document.getElementById('shoot-button').style.display       = 'block';
       fullscreenBtn.style.display                                 = 'block';
-      upBtn.style.display                                          = 'block';
-      sprintBtn.style.display                                      = 'block';
 
       fullscreenBtn.addEventListener('click', () => {
         const el = document.documentElement;
@@ -92,30 +83,6 @@
       document.addEventListener('touchstart', resetIdleTimer, { passive: true });
       document.addEventListener('mousemove', resetIdleTimer, { passive: true });
       resetIdleTimer();
-
-      upBtn.addEventListener('touchstart', () => {
-        const now = performance.now();
-        if (now - lastTapUp < 300) {
-          // enter fly mode
-          downBtn.style.display = 'block';
-        } else {
-          // single-tap jump
-        }
-        lastTapUp = now;
-      });
-      upBtn.addEventListener('touchend', () => { /* end jump/ascend */ });
-
-      downBtn.addEventListener('touchstart', () => {
-        const now = performance.now();
-        if (now - lastTapDown < 300) {
-          // exit fly mode
-          downBtn.style.display = 'none';
-        } else {
-          // single-tap descend
-        }
-        lastTapDown = now;
-      });
-      downBtn.addEventListener('touchend', () => { /* end descend */ });
     });
   </script>
 

--- a/js/main.js
+++ b/js/main.js
@@ -3,14 +3,12 @@
 import * as THREE from '../vendor/three.module.js';
 import SimplexNoise from 'https://cdn.jsdelivr.net/npm/simplex-noise@3.0.0/dist/esm/simplex-noise.js';
 
-window.onload = () => {
+const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
-  const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+window.onload = () => {
   function setupMobileControls() {
     document.getElementById('joystick-zone').style.display = 'block';
     document.getElementById('shoot-button').style.display = 'block';
-    document.getElementById('up-button').style.display = 'block';
-    document.getElementById('sprint-button').style.display = 'block';
 
     // ─── Movement Joystick ───────────────
     const joystick = nipplejs.create({
@@ -18,34 +16,31 @@ window.onload = () => {
       mode: 'static',
       position: { left: '75px', bottom: '75px' },
       color: 'white',
-      size: 100
+      size: 200
     });
 
     joystick.on('move', (evt, data) => {
       const x = data.vector.x;
       const y = data.vector.y;
-      move.f = y >  0.3 ? 1 : 0;
-      move.b = y < -0.3 ? 1 : 0;
-      move.l = x < -0.3 ? 1 : 0;
-      move.r = x >  0.3 ? 1 : 0;
-      autoSprint = (y > 0.85 && Math.abs(x) < 0.3);
-      shiftHeld = manualSprint || autoSprint;
+      move.f = Math.max(0, y);
+      move.b = Math.max(0, -y);
+      move.l = Math.max(0, -x);
+      move.r = Math.max(0, x);
+      joystickIntensity = Math.min(1, data.distance / (joystick.options.size / 2));
+      shiftHeld = manualSprint || joystickIntensity > 0.9;
     });
 
     joystick.on('end', () => {
       move.f = move.b = move.l = move.r = 0;
-      autoSprint = false;
-      shiftHeld = manualSprint || autoSprint;
+      joystickIntensity = 0;
+      shiftHeld = manualSprint || joystickIntensity > 0.9;
     });
 
     // ─── Screen Drag Look ───────────────
     let lookTouch = null, lastLX = 0, lastLY = 0;
     const okLook = el =>
       !el.closest('#joystick-zone') &&
-      !el.closest('#shoot-button') &&
-      !el.closest('#up-button') &&
-      !el.closest('#down-button') &&
-      !el.closest('#sprint-button');
+      !el.closest('#shoot-button');
 
     renderer.domElement.addEventListener('touchstart', e => {
       const t = e.changedTouches[0];
@@ -91,59 +86,41 @@ window.onload = () => {
       shootProjectile();
     });
 
-    // ─── Jump/Fly Controls ───────────────
-    const upBtn   = document.getElementById('up-button');
-    const downBtn = document.getElementById('down-button');
+    // ─── Screen Tap Flight Controls ──────
+    let lastTopTap = 0;
+    let lastBottomTap = 0;
 
-    let lastUpTap = 0;
-    let lastDownTap = 0;
-
-    const onUpStart = () => {
+    const handleScreenTouch = e => {
+      if (e.touches.length > 1) return;
+      const t = e.changedTouches[0];
+      if (!t || t.target.closest('#joystick-zone') || t.target.closest('#shoot-button')) return;
+      const top = t.clientY < innerHeight / 2;
       const now = performance.now();
-      if (now - lastUpTap < 300) {
-        flyMode = true;
-        downBtn.style.display = 'block';
-      } else if (!flyMode && onGround) {
-        vertVel = 12;
-        onGround = false;
+      if (top) {
+        if (now - lastTopTap < 300) {
+          flyMode = true;
+        } else if (!flyMode && onGround) {
+          vertVel = 12;
+          onGround = false;
+        } else if (flyMode) {
+          spaceHeld = true;
+        }
+        lastTopTap = now;
+      } else {
+        if (now - lastBottomTap < 300) {
+          flyMode = false;
+        } else if (flyMode) {
+          zHeld = true;
+        }
+        lastBottomTap = now;
       }
-      lastUpTap = now;
-      spaceHeld = true;
     };
 
-    const onUpEnd = () => { spaceHeld = false; };
+    const endScreenTouch = () => { spaceHeld = false; zHeld = false; };
 
-    upBtn.addEventListener('touchstart', e => { e.preventDefault(); onUpStart(); });
-    upBtn.addEventListener('touchend',   e => { e.preventDefault(); onUpEnd(); });
-
-    const onDownStart = () => {
-      const now = performance.now();
-      if (now - lastDownTap < 300) {
-        flyMode = false;
-        downBtn.style.display = 'none';
-      }
-      zHeld  = true;
-      lastDownTap = now;
-    };
-
-    const onDownEnd = () => { zHeld  = false; };
-
-    downBtn.addEventListener('touchstart', e => { e.preventDefault(); onDownStart(); });
-    downBtn.addEventListener('touchend',   e => { e.preventDefault(); onDownEnd(); });
-
-    // ─── Sprint Button ───────────────────
-    const sprintBtn = document.getElementById('sprint-button');
-    const onSprintStart = () => {
-      manualSprint = true;
-      shiftHeld = manualSprint || autoSprint;
-    };
-    const onSprintEnd   = () => {
-      manualSprint = false;
-      shiftHeld = manualSprint || autoSprint;
-    };
-    sprintBtn.addEventListener('touchstart', e => { e.preventDefault(); onSprintStart(); });
-    sprintBtn.addEventListener('touchend',   e => { e.preventDefault(); onSprintEnd(); });
-    sprintBtn.addEventListener('touchcancel', onSprintEnd);
+    renderer.domElement.addEventListener('touchstart', handleScreenTouch, { passive: true });
+    renderer.domElement.addEventListener('touchend', endScreenTouch, { passive: true });
+    renderer.domElement.addEventListener('touchcancel', endScreenTouch, { passive: true });
   }
 
 
@@ -199,7 +176,7 @@ let   yaw = 0, pitch = 0;
 let   charging = false, chargeStart = 0, currentCharge = 0;
 let   vertVel = 0, onGround = false, flyMode = false;
 let   spaceHeld = false, zHeld  = false;
-let   manualSprint = false, autoSprint = false, shiftHeld = false;
+let   manualSprint = false, shiftHeld = false, joystickIntensity = 0;
 let   lastSpace = 0, lastZ = 0;
 const move = { f:0, b:0, l:0, r:0 };
 
@@ -685,7 +662,7 @@ document.addEventListener('keydown',e=>{
     case'KeyA':move.l=1;break; case'KeyD':move.r=1;break;
     case'ShiftLeft':case'ShiftRight':
       manualSprint = true;
-      shiftHeld = manualSprint || autoSprint;
+      shiftHeld = manualSprint || joystickIntensity > 0.9;
       break;
     case'Space':
       spaceHeld=true;
@@ -705,7 +682,7 @@ document.addEventListener('keyup',e=>{
     case'KeyA':move.l=0;break; case'KeyD':move.r=0;break;
     case'ShiftLeft':case'ShiftRight':
       manualSprint = false;
-      shiftHeld = manualSprint || autoSprint;
+      shiftHeld = manualSprint || joystickIntensity > 0.9;
       break;
     case'Space':spaceHeld=false;break;
     case'KeyZ':case'KeyZ':zHeld =false;break;
@@ -801,8 +778,9 @@ function animate(now){
   const dir=new THREE.Vector3(move.r-move.l,0,move.b-move.f);
   if(dir.lengthSq()){
     dir.normalize().applyAxisAngle(new THREE.Vector3(0,1,0),yaw);
-    const baseSpeed=flyMode?20:10;
-    character.position.addScaledVector(dir, baseSpeed*(shiftHeld?2:1)*dt);
+    const baseSpeed = flyMode ? 20 : 10;
+    const speedMult = isMobile ? 1 + joystickIntensity : (shiftHeld ? 2 : 1);
+    character.position.addScaledVector(dir, baseSpeed * speedMult * dt);
   }
 
   /* vertical */

--- a/styles/style.css
+++ b/styles/style.css
@@ -68,7 +68,7 @@ canvas {
 }
 #joystick-zone {
   bottom: 20px; left: 20px;
-  width: 150px; height: 150px;
+  width: 200px; height: 200px;
 }
 #joystick-look-zone {
   top: 20px; right: 20px;
@@ -79,7 +79,7 @@ canvas {
 #shoot-button {
   display: none;
   position: absolute;
-  top: 30px; right: 160px;
+  bottom: 20px; right: 20px;
   width: 60px; height: 60px;
   background: rgba(255,255,255,0.15);
   border-radius: 50%;
@@ -115,63 +115,3 @@ canvas {
   transition: opacity 0.8s ease;
 }
 
-/* Jump / Fly Buttons */
-#up-button,
-#down-button {
-  display: none;
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 60px; height: 60px;
-  background: rgba(255,255,255,0.15);
-  border: 2px solid white;
-  border-radius: 50%;
-  z-index: 12;
-}
-#up-button { bottom: 90px; }
-#down-button { bottom: 20px; }
-#sprint-button {
-  display: none;
-  position: absolute;
-  top: 30px;
-  right: 90px;
-  width: 60px;
-  height: 60px;
-  background: rgba(255,255,255,0.15);
-  border: 2px solid white;
-  border-radius: 50%;
-  z-index: 12;
-}
-#sprint-button::before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  border-width: 10px 0 10px 14px;
-  border-color: transparent transparent transparent white;
-  transform: translate(-40%, -50%);
-}
-#sprint-button:active {
-  transform: scale(1.1);
-  opacity: 0.9;
-}
-#up-button::before,
-#down-button::before {
-  content: '';
-  position: absolute;
-  left: 50%; top: 50%;
-  width: 0; height: 0;
-  border-style: solid;
-  transform: translate(-50%, -50%);
-}
-#up-button::before {
-  border-width: 0 10px 12px 10px;
-  border-color: transparent transparent white transparent;
-}
-#down-button::before {
-  border-width: 12px 10px 0 10px;
-  border-color: white transparent transparent transparent;
-}


### PR DESCRIPTION
## Summary
- remove sprint/up/down buttons
- scale joystick and use distance for speed
- add screen tap controls for flying and jumping
- move shoot button to bottom-right

## Testing
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_68568af0ff74832682d03a50ac94dcf1