### PR TITLE
Update sky and mobile controls

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -16,7 +16,7 @@ window.onload = () => {
       mode: 'static',
       position: { left: '75px', bottom: '75px' },
       color: 'white',
-      size: 200
+      size: 150
     });
 
     joystick.on('move', (evt, data) => {
@@ -230,10 +230,8 @@ function generateSkyTexture(size){
 // Simple light gray sky sphere with PBR material
 skyMesh = new THREE.Mesh(
   new THREE.SphereGeometry(350, 64, 64),
-  new THREE.MeshStandardMaterial({
-    color: 0xd3d3d3,
-    metalness: 1,
-    roughness: 1,
+  new THREE.MeshBasicMaterial({
+    color: 0x87cefa, // consistent sky color
     side: THREE.BackSide
   })
 );

--- a/styles/style.css
+++ b/styles/style.css
@@ -68,7 +68,7 @@ canvas {
 }
 #joystick-zone {
   bottom: 20px; left: 20px;
-  width: 200px; height: 200px;
+  width: 150px; height: 150px; /* smaller joystick area */
 }
 #joystick-look-zone {
   top: 20px; right: 20px;
@@ -80,18 +80,15 @@ canvas {
   display: none;
   position: absolute;
   bottom: 20px; right: 20px;
-  width: 60px; height: 60px;
+  width: 70px; height: 70px; /* slightly larger */
   background: rgba(255,255,255,0.15);
+  border: 3px solid red; /* red outline */
   border-radius: 50%;
   z-index: 11;
 }
+/* remove center dot */
 #shoot-button::after {
-  content: '';
-  position: absolute;
-  top: 50%; left: 50%;
-  width: 12px; height: 12px;
-  background: red; border-radius: 50%;
-  transform: translate(-50%, -50%);
+  content: none;
 }
 #shoot-button:active {
   transform: scale(1.1);


### PR DESCRIPTION
## Summary
- keep sky color uniform with MeshBasicMaterial
- resize joystick and shoot button
- change shoot button design to outline-only

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68568ea77e48832682c836c08d6ab0e5