### PR TITLE
Adjust sky material to light gray metal

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -230,8 +230,11 @@ function generateSkyTexture(size){
 // Simple light gray sky sphere with PBR material
 skyMesh = new THREE.Mesh(
   new THREE.SphereGeometry(350, 64, 64),
-  new THREE.MeshBasicMaterial({
-    color: 0x87cefa, // consistent sky color
+  // Use a standard material so we can control metalness and roughness
+  new THREE.MeshStandardMaterial({
+    color: 0xd3d3d3,    // light gray
+    metalness: 1,
+    roughness: 1,
     side: THREE.BackSide
   })
 );


### PR DESCRIPTION
## Summary
- switch sky sphere to MeshStandardMaterial
- set sky color to light gray and enable full metalness and roughness

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68568fe5115c832697739634e6cfa5da