### PR TITLE
Make sky light gray

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -188,7 +188,8 @@ let targetMesh     = null;   // Three.js mesh for the pillar/flag
 
 /* ──────────────────── DOM + RENDER TARGET SET-UP ─────────────────── */
 const scene     = new THREE.Scene();
-scene.background = new THREE.Color(0xd3d3d3);
+// Use a lighter gray to give the world a softer backdrop
+scene.background = new THREE.Color(0xcccccc);
 // --- SKY SPHERE SETUP ---
 let skyMesh;
 function generateSkyTexture(size){
@@ -232,7 +233,7 @@ skyMesh = new THREE.Mesh(
   new THREE.SphereGeometry(350, 64, 64),
   // Use a standard material so we can control metalness and roughness
   new THREE.MeshStandardMaterial({
-    color: 0xd3d3d3,    // light gray
+    color: 0xcccccc,    // light gray
     metalness: 1,
     roughness: 1,
     side: THREE.BackSide


### PR DESCRIPTION
## Summary
- tweak the scene background
- use the same light gray for the sky sphere

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6856906a98d88326a9dd057657dc59b6