### PR TITLE
Add mobile flight control buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,9 @@
       Joystick (left) → Move<br>
       Drag screen → Look<br>
       Red Button → Shoot<br>
-      Tap top ↔ Jump / Ascend<br>
-      Tap bottom ↔ Descend<br>
+      Tap top or ▲ ↔ Jump / Ascend<br>
+      Tap bottom or ▼ ↔ Descend<br>
+      Fly Btn ↔ Fly / Walk<br>
       ⛶ → Fullscreen
     </span>
   </div>
@@ -42,6 +43,9 @@
   <div id="joystick-zone"></div>
   <div id="joystick-look-zone"></div>
   <div id="shoot-button"></div>
+  <div id="ascend-button" class="fly-control">▲</div>
+  <div id="descend-button" class="fly-control">▼</div>
+  <div id="fly-toggle-button" class="fly-control">Fly</div>
 
   <!-- Three.js & Noise libs are imported by js/main.js -->
 
@@ -69,6 +73,9 @@
       document.getElementById('controls-mobile').style.display    = 'inline';
       document.getElementById('joystick-zone').style.display      = 'block';
       document.getElementById('shoot-button').style.display       = 'block';
+      document.getElementById('ascend-button').style.display      = 'block';
+      document.getElementById('descend-button').style.display     = 'block';
+      document.getElementById('fly-toggle-button').style.display  = 'block';
       fullscreenBtn.style.display                                 = 'block';
 
       fullscreenBtn.addEventListener('click', () => {

--- a/js/main.js
+++ b/js/main.js
@@ -40,7 +40,10 @@ window.onload = () => {
     let lookTouch = null, lastLX = 0, lastLY = 0;
     const okLook = el =>
       !el.closest('#joystick-zone') &&
-      !el.closest('#shoot-button');
+      !el.closest('#shoot-button') &&
+      !el.closest('#ascend-button') &&
+      !el.closest('#descend-button') &&
+      !el.closest('#fly-toggle-button');
 
     renderer.domElement.addEventListener('touchstart', e => {
       const t = e.changedTouches[0];
@@ -93,7 +96,12 @@ window.onload = () => {
     const handleScreenTouch = e => {
       if (e.touches.length > 1) return;
       const t = e.changedTouches[0];
-      if (!t || t.target.closest('#joystick-zone') || t.target.closest('#shoot-button')) return;
+      if (!t ||
+          t.target.closest('#joystick-zone') ||
+          t.target.closest('#shoot-button') ||
+          t.target.closest('#ascend-button') ||
+          t.target.closest('#descend-button') ||
+          t.target.closest('#fly-toggle-button')) return;
       const top = t.clientY < innerHeight / 2;
       const now = performance.now();
       if (top) {
@@ -121,6 +129,19 @@ window.onload = () => {
     renderer.domElement.addEventListener('touchstart', handleScreenTouch, { passive: true });
     renderer.domElement.addEventListener('touchend', endScreenTouch, { passive: true });
     renderer.domElement.addEventListener('touchcancel', endScreenTouch, { passive: true });
+
+    // ─── Dedicated Flight Buttons ────────
+    const ascBtn  = document.getElementById('ascend-button');
+    const descBtn = document.getElementById('descend-button');
+    const flyBtn  = document.getElementById('fly-toggle-button');
+
+    ascBtn.addEventListener('touchstart', e => { e.preventDefault(); spaceHeld = true; });
+    ascBtn.addEventListener('touchend',   e => { e.preventDefault(); spaceHeld = false; });
+
+    descBtn.addEventListener('touchstart', e => { e.preventDefault(); zHeld = true; });
+    descBtn.addEventListener('touchend',   e => { e.preventDefault(); zHeld = false; });
+
+    flyBtn.addEventListener('touchend', e => { e.preventDefault(); flyMode = !flyMode; });
   }
 
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -112,3 +112,24 @@ canvas {
   transition: opacity 0.8s ease;
 }
 
+/* Mobile flight controls */
+.fly-control {
+  display: none;
+  position: absolute;
+  right: 20px;
+  width: 55px;
+  height: 55px;
+  background: rgba(255,255,255,0.15);
+  color: white;
+  font-family: monospace;
+  font-size: 20px;
+  border: 2px solid #fff;
+  border-radius: 8px;
+  text-align: center;
+  line-height: 55px;
+  z-index: 11;
+}
+#ascend-button { bottom: 100px; }
+#descend-button { bottom: 165px; }
+#fly-toggle-button { bottom: 230px; }
+


### PR DESCRIPTION
## Summary
- add on-screen buttons for ascending, descending and toggling fly mode
- show these buttons and update mobile instructions
- style the new flight controls
- update mobile controls script to handle new buttons

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685690c826988326997935be509c2d2f