### PR TITLE
Add recall via shoot button

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ Textures now use the maximum supported anisotropy value for crisper detail at gl
 The terrain is now generated on the client using Simplex noise so no tile
 server or baking step is required. Simply start the web and WebSocket servers
 with `npm start` and connect.
+
+### Gameplay
+
+- Press the shoot button again to recall your boomerang early if it's already flying.

--- a/index.html
+++ b/index.html
@@ -21,12 +21,13 @@
       Shift → Sprint<br>
       Space ↔ Fly Mode<br>
       Ctrl → Descend<br>
+      LMB → Shoot / Recall<br>
       Esc → Reset
     </span>
     <span id="controls-mobile" style="display: none;">
       Joystick (left) → Move<br>
       Drag screen → Look<br>
-      Red Button → Shoot<br>
+      Red Button → Shoot / Recall<br>
       Tap top or ▲ ↔ Jump / Ascend<br>
       Tap bottom or ▼ ↔ Descend<br>
       Fly Btn ↔ Fly / Walk<br>

--- a/js/main.js
+++ b/js/main.js
@@ -77,7 +77,7 @@ window.onload = () => {
     const shootBtn = document.getElementById('shoot-button');
     shootBtn.addEventListener('touchstart', e => {
       e.preventDefault();
-      if (!loadedBullet) return;
+      if (!loadedBullet) { recallProjectile(); return; }
       charging = true;
       chargeStart = performance.now();
     });
@@ -493,7 +493,8 @@ function initCharacter(){
   /* mouse input for charge shot */
 if (!isMobile) {
   renderer.domElement.addEventListener('mousedown', e => {
-    if (e.button !== 0 || !loadedBullet) return;
+    if (e.button !== 0) return;
+    if (!loadedBullet) { recallProjectile(); return; }
     charging = true;
     chargeStart = performance.now();
   });
@@ -545,6 +546,18 @@ function shootProjectile(){
     }));
   }
   loadedBullet=null;
+}
+
+function recallProjectile(){
+  if(loadedBullet){
+    charging = false;
+    currentCharge = 0;
+    shootProjectile();
+    return;
+  }
+  for(const p of projectiles){
+    if(p.id===undefined) p.returning = true;
+  }
 }
 function teleport(){
   const x=(Math.random()-0.5)*GRID*SPAN, z=(Math.random()-0.5)*GRID*SPAN;


### PR DESCRIPTION
## Summary
- allow pressing the shoot button when no boomerang is loaded to recall it
- update on-screen controls to note shoot/recall button
- document recall mechanic in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685692f545a08326ba72712dc115c2b9