### PR TITLE
Remove mobile ascend/descend controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,6 @@
   <div id="joystick-zone"></div>
   <div id="joystick-look-zone"></div>
   <div id="shoot-button"></div>
-  <div id="ascend-button" class="fly-control">▲</div>
-  <div id="descend-button" class="fly-control">▼</div>
   <div id="fly-toggle-button" class="fly-control">Fly</div>
 
   <!-- Three.js & Noise libs are imported by js/main.js -->
@@ -74,8 +72,6 @@
       document.getElementById('controls-mobile').style.display    = 'inline';
       document.getElementById('joystick-zone').style.display      = 'block';
       document.getElementById('shoot-button').style.display       = 'block';
-      document.getElementById('ascend-button').style.display      = 'block';
-      document.getElementById('descend-button').style.display     = 'block';
       document.getElementById('fly-toggle-button').style.display  = 'block';
       fullscreenBtn.style.display                                 = 'block';
 

--- a/js/main.js
+++ b/js/main.js
@@ -41,8 +41,6 @@ window.onload = () => {
     const okLook = el =>
       !el.closest('#joystick-zone') &&
       !el.closest('#shoot-button') &&
-      !el.closest('#ascend-button') &&
-      !el.closest('#descend-button') &&
       !el.closest('#fly-toggle-button');
 
     renderer.domElement.addEventListener('touchstart', e => {
@@ -99,8 +97,6 @@ window.onload = () => {
       if (!t ||
           t.target.closest('#joystick-zone') ||
           t.target.closest('#shoot-button') ||
-          t.target.closest('#ascend-button') ||
-          t.target.closest('#descend-button') ||
           t.target.closest('#fly-toggle-button')) return;
       const top = t.clientY < innerHeight / 2;
       const now = performance.now();
@@ -130,16 +126,8 @@ window.onload = () => {
     renderer.domElement.addEventListener('touchend', endScreenTouch, { passive: true });
     renderer.domElement.addEventListener('touchcancel', endScreenTouch, { passive: true });
 
-    // ─── Dedicated Flight Buttons ────────
-    const ascBtn  = document.getElementById('ascend-button');
-    const descBtn = document.getElementById('descend-button');
+    // ─── Fly Toggle Button ───────────────
     const flyBtn  = document.getElementById('fly-toggle-button');
-
-    ascBtn.addEventListener('touchstart', e => { e.preventDefault(); spaceHeld = true; });
-    ascBtn.addEventListener('touchend',   e => { e.preventDefault(); spaceHeld = false; });
-
-    descBtn.addEventListener('touchstart', e => { e.preventDefault(); zHeld = true; });
-    descBtn.addEventListener('touchend',   e => { e.preventDefault(); zHeld = false; });
 
     flyBtn.addEventListener('touchend', e => { e.preventDefault(); flyMode = !flyMode; });
   }

--- a/styles/style.css
+++ b/styles/style.css
@@ -129,7 +129,5 @@ canvas {
   line-height: 55px;
   z-index: 11;
 }
-#ascend-button { bottom: 100px; }
-#descend-button { bottom: 165px; }
 #fly-toggle-button { bottom: 230px; }
 


### PR DESCRIPTION
## Summary
- remove ascend/descend buttons from mobile UI
- clean up associated JavaScript logic and CSS

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856954609b4832686013f8a3d05c361