### PR TITLE
Remove mobile fly toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,6 @@
   <div id="joystick-zone"></div>
   <div id="joystick-look-zone"></div>
   <div id="shoot-button"></div>
-  <div id="ascend-button" class="fly-control">▲</div>
-  <div id="descend-button" class="fly-control">▼</div>
-  <div id="fly-toggle-button" class="fly-control">Fly</div>
 
   <!-- Three.js & Noise libs are imported by js/main.js -->
 
@@ -74,9 +71,6 @@
       document.getElementById('controls-mobile').style.display    = 'inline';
       document.getElementById('joystick-zone').style.display      = 'block';
       document.getElementById('shoot-button').style.display       = 'block';
-      document.getElementById('ascend-button').style.display      = 'block';
-      document.getElementById('descend-button').style.display     = 'block';
-      document.getElementById('fly-toggle-button').style.display  = 'block';
       fullscreenBtn.style.display                                 = 'block';
 
       fullscreenBtn.addEventListener('click', () => {

--- a/js/main.js
+++ b/js/main.js
@@ -40,10 +40,7 @@ window.onload = () => {
     let lookTouch = null, lastLX = 0, lastLY = 0;
     const okLook = el =>
       !el.closest('#joystick-zone') &&
-      !el.closest('#shoot-button') &&
-      !el.closest('#ascend-button') &&
-      !el.closest('#descend-button') &&
-      !el.closest('#fly-toggle-button');
+      !el.closest('#shoot-button');
 
     renderer.domElement.addEventListener('touchstart', e => {
       const t = e.changedTouches[0];
@@ -98,10 +95,7 @@ window.onload = () => {
       const t = e.changedTouches[0];
       if (!t ||
           t.target.closest('#joystick-zone') ||
-          t.target.closest('#shoot-button') ||
-          t.target.closest('#ascend-button') ||
-          t.target.closest('#descend-button') ||
-          t.target.closest('#fly-toggle-button')) return;
+          t.target.closest('#shoot-button')) return;
       const top = t.clientY < innerHeight / 2;
       const now = performance.now();
       if (top) {
@@ -130,18 +124,7 @@ window.onload = () => {
     renderer.domElement.addEventListener('touchend', endScreenTouch, { passive: true });
     renderer.domElement.addEventListener('touchcancel', endScreenTouch, { passive: true });
 
-    // ─── Dedicated Flight Buttons ────────
-    const ascBtn  = document.getElementById('ascend-button');
-    const descBtn = document.getElementById('descend-button');
-    const flyBtn  = document.getElementById('fly-toggle-button');
-
-    ascBtn.addEventListener('touchstart', e => { e.preventDefault(); spaceHeld = true; });
-    ascBtn.addEventListener('touchend',   e => { e.preventDefault(); spaceHeld = false; });
-
-    descBtn.addEventListener('touchstart', e => { e.preventDefault(); zHeld = true; });
-    descBtn.addEventListener('touchend',   e => { e.preventDefault(); zHeld = false; });
-
-    flyBtn.addEventListener('touchend', e => { e.preventDefault(); flyMode = !flyMode; });
+    // (Fly toggle button removed)
   }
 
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -112,24 +112,4 @@ canvas {
   transition: opacity 0.8s ease;
 }
 
-/* Mobile flight controls */
-.fly-control {
-  display: none;
-  position: absolute;
-  right: 20px;
-  width: 55px;
-  height: 55px;
-  background: rgba(255,255,255,0.15);
-  color: white;
-  font-family: monospace;
-  font-size: 20px;
-  border: 2px solid #fff;
-  border-radius: 8px;
-  text-align: center;
-  line-height: 55px;
-  z-index: 11;
-}
-#ascend-button { bottom: 100px; }
-#descend-button { bottom: 165px; }
-#fly-toggle-button { bottom: 230px; }
 


### PR DESCRIPTION
## Summary
- delete fly toggle button from mobile markup
- strip fly button references from script and CSS
- clean up unused styles after removing mobile flight controls

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856954609b4832686013f8a3d05c361