### PR TITLE
Remove fly button on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,6 @@
   <div id="joystick-zone"></div>
   <div id="joystick-look-zone"></div>
   <div id="shoot-button"></div>
-  <div id="fly-toggle-button" class="fly-control">Fly</div>
 
   <!-- Three.js & Noise libs are imported by js/main.js -->
 
@@ -72,7 +71,6 @@
       document.getElementById('controls-mobile').style.display    = 'inline';
       document.getElementById('joystick-zone').style.display      = 'block';
       document.getElementById('shoot-button').style.display       = 'block';
-      document.getElementById('fly-toggle-button').style.display  = 'block';
       fullscreenBtn.style.display                                 = 'block';
 
       fullscreenBtn.addEventListener('click', () => {

--- a/js/main.js
+++ b/js/main.js
@@ -126,10 +126,6 @@ window.onload = () => {
     renderer.domElement.addEventListener('touchend', endScreenTouch, { passive: true });
     renderer.domElement.addEventListener('touchcancel', endScreenTouch, { passive: true });
 
-    // ─── Fly Toggle Button ───────────────
-    const flyBtn  = document.getElementById('fly-toggle-button');
-
-    flyBtn.addEventListener('touchend', e => { e.preventDefault(); flyMode = !flyMode; });
   }
 
 


### PR DESCRIPTION
## Summary
- remove fly toggle button element from page
- stop showing fly button in mobile setup
- drop unused fly button event listener

## Testing
- `node --check js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_685696c721588326818e61c519799b96