### PR TITLE
Add player health, PvP damage and terrain attacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
   <div id="joystick-look-zone"></div>
   <div id="shoot-button"></div>
 
+  <div id="health-bar"><div id="health-fill"></div></div>
+
   <!-- Three.js & Noise libs are imported by js/main.js -->
 
   <!-- Mobile UI behavior (joystick, fullscreen hints, fly/jump) -->

--- a/js/main.js
+++ b/js/main.js
@@ -145,6 +145,7 @@ const MIN_CRATER      = DEFORM_RADIUS, MAX_CRATER   = DEFORM_RADIUS * 3;
 const NOISE_SCALE     = 0.004, NOISE_AMP = 30, NOISE_OCTS = 6;
 const TEXTURE_SIZE    = 256;               // resolution of procedural texture
 const MAX_DT          = 0.05;
+const MAX_HEALTH      = 100;
 const mapSeed         = '🌎';                 // constant → identical terrain
 const noiseSky        = new SimplexNoise(mapSeed + 'sky');
 
@@ -160,6 +161,7 @@ const tmpVec      = new THREE.Vector3();
 
 let   myId        = null;
 let   myColor     = new THREE.Color(0x222222);
+let   myHealth    = MAX_HEALTH;
 // ─── insert here ───
 const scores = new Map();  // id → score
 
@@ -173,6 +175,11 @@ function updateScoreboard() {
       li.textContent = (id === myId ? 'You' : id) + ': ' + pts;
       ol.appendChild(li);
     });
+}
+
+function updateHealthBar() {
+  const fill = document.getElementById('health-fill');
+  if (fill) fill.style.width = `${myHealth}%`;
 }
 let   character, bodyMesh, headMesh, Larm, Rarm, Lleg, Rleg;
 let   boxGeo, octGeo, bulletMat, loadedBullet = null;
@@ -349,6 +356,17 @@ case 'scoreUpdate': {
         if (av.position.y < gY) av.position.y = gY;
       });
     } break;
+
+    case 'terrainAttack': {
+      const { x,z,r } = msg;
+      deformTerrain(new THREE.Vector3(x,0,z), r, DEFORM_DEPTH);
+    } break;
+
+    case 'playerDied': {
+      if (msg.id === myId) {
+        teleport();
+      }
+    } break;
   }
 });
 
@@ -356,6 +374,7 @@ case 'scoreUpdate': {
 noise = new SimplexNoise(mapSeed);
 initTerrain().then(() => {
   initCharacter();
+  updateHealthBar();
   requestAnimationFrame(animate);
 });
 
@@ -520,7 +539,8 @@ function shootProjectile(){
   projectiles.push({
     mesh:loadedBullet, velocity:dir.clone().multiplyScalar(speedOut),
     travelled:0, maxRange:rangeOut, craterRad:craterR,
-    returning:false, ttl:TTL_SECONDS, id:undefined
+    returning:false, ttl:TTL_SECONDS, id:undefined,
+    owner: myId
   });
 
   if(socket.readyState===1&&myId){
@@ -602,7 +622,17 @@ function makeRemoteAvatar(col){
   }
 
   updateScoreboard();
- 
+
+  if (pack[myId] && typeof pack[myId].health === 'number') {
+    myHealth = pack[myId].health;
+    const scale = Math.max(0, myHealth / MAX_HEALTH);
+    if (bodyMesh) {
+      bodyMesh.scale.y = scale;
+      bodyMesh.visible = scale > 0;
+    }
+    updateHealthBar();
+  }
+
   /* ---------- players ---------- */
   for(const [id,st] of Object.entries(pack)){
     if(id===myId) continue;
@@ -611,6 +641,13 @@ function makeRemoteAvatar(col){
     av.position.set(st.x,st.y,st.z);
     av.rotation.y = st.yaw;
     av.userData.mat.color.set(st.color);
+
+    if (typeof st.health === 'number') {
+      av.userData.health = st.health;
+      const scale = Math.max(0, st.health / MAX_HEALTH);
+      av.userData.body.scale.y = scale;
+      av.userData.body.visible = scale > 0;
+    }
 
     const geo = st.flyMode ? av.userData.octGeo : av.userData.boxGeo;
     av.userData.body.geometry = geo;
@@ -667,7 +704,8 @@ function makeRemoteAvatar(col){
       craterRad:THREE.MathUtils.lerp(MIN_CRATER,MAX_CRATER,s.c),
       returning:false,
       ttl:TTL_SECONDS,
-      id:s.id
+      id:s.id,
+      owner:s.owner
     });
     remoteShots.set(s.id,true);
   });
@@ -755,6 +793,22 @@ function animate(now){
 
     const groundY=meshHeightAt(p.mesh.position.x,p.mesh.position.z);
     const hitGround=p.mesh.position.y<=groundY;
+
+    let hitPlayer = false;
+    if(p.owner===myId && !p.returning){
+      ghosts.forEach((av,id)=>{
+        if(hitPlayer) return;
+        const d=p.mesh.position.distanceTo(av.position);
+        if(d<1){
+          socket.send(JSON.stringify({t:'hitPlayer', target:id, shotId:p.id}));
+          hitPlayer=true;
+        }
+      });
+      if(hitPlayer){
+        catchBoomerang(p);
+        continue;
+      }
+    }
     if(hitGround){
           if (hitGround && activeTarget) {
       // see if we’re within radius of the active target

--- a/server.js
+++ b/server.js
@@ -16,6 +16,11 @@ const NOISE_SEED = 'sig-terrain-v1';
 // Bounds for where targets can spawn
 const TERRAIN_HALF  = 100;
 const TARGET_RADIUS = 5;
+const MAX_HEALTH    = 100;
+const PROJECTILE_DAMAGE = 25;
+const TERRAIN_ATTACK_INTERVAL = 15000;
+const TERRAIN_ATTACK_RADIUS   = 3;
+const TERRAIN_DAMAGE = 25;
 
 /* ────────────────── GLOBAL STATE ──────────────────────── */
 // WebSocket server instance
@@ -59,7 +64,7 @@ function packSnapshot() {
     players: Object.fromEntries(
       [...players.entries()].map(([id,p]) => [
         id,
-        { ...p.state, color: p.color, score: p.score || 0 }
+        { ...p.state, color: p.color, score: p.score || 0, health: p.health }
       ])
     ),
     // array of projectile records
@@ -81,6 +86,27 @@ function spawnTarget() {
 setTimeout(spawnTarget, 2000);
 setInterval(spawnTarget, 30000);
 
+function terrainAttack(){
+  if(players.size===0) return;
+  const arr=[...players.values()];
+  const base=arr[Math.random()*arr.length|0].state;
+  const x=(base.x||0)+(Math.random()*6-3);
+  const z=(base.z||0)+(Math.random()*6-3);
+  const msg=JSON.stringify({t:'terrainAttack', x, z, r:TERRAIN_ATTACK_RADIUS});
+  wss.clients.forEach(c=>c.readyState===1&&c.send(msg));
+  for(const [id,p] of players){
+    const dx=(p.state.x||0)-x; const dz=(p.state.z||0)-z;
+    if(Math.hypot(dx,dz)<=TERRAIN_ATTACK_RADIUS){
+      p.health=Math.max(0,p.health-TERRAIN_DAMAGE);
+      if(p.health<=0){
+        wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id})));
+        p.health=MAX_HEALTH;
+      }
+    }
+  }
+}
+setInterval(terrainAttack, TERRAIN_ATTACK_INTERVAL);
+
 /* ─────────────── CLIENT CONNECTION ───────────────────── */
 // Handle new WebSocket connections
 wss.on('connection', ws => {
@@ -89,7 +115,7 @@ wss.on('connection', ws => {
   const color = pickNamedColour();
 
   // Initialize player state + score
-  players.set(id, { input:{}, state:{}, color, score: 0 });
+  players.set(id, { input:{}, state:{}, color, score: 0, health: MAX_HEALTH });
   scores.set(id, 0);
 
   // Send welcome packet with assigned ID, color, and noise seed
@@ -159,6 +185,21 @@ wss.on('connection', ws => {
           // Respawn the next target
           activeTarget = null;
           spawnTarget();
+        }
+        break;
+      }
+
+      case 'hitPlayer': {
+        const target = players.get(msg.target);
+        if (target) {
+          target.health = Math.max(0, target.health - PROJECTILE_DAMAGE);
+          const idx = projectiles.findIndex(p => p.id===msg.shotId);
+          if (idx !== -1) projectiles.splice(idx,1);
+          if (target.health <= 0) {
+            wss.clients.forEach(c => c.readyState===1 &&
+              c.send(JSON.stringify({ t:'playerDied', id: msg.target })));
+            target.health = MAX_HEALTH;
+          }
         }
         break;
       }

--- a/styles/style.css
+++ b/styles/style.css
@@ -131,3 +131,22 @@ canvas {
 }
 #fly-toggle-button { bottom: 230px; }
 
+/* Health bar */
+#health-bar {
+  position: absolute;
+  bottom: 15px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 200px;
+  height: 20px;
+  background: rgba(0,0,0,0.5);
+  border: 1px solid #fff;
+  border-radius: 4px;
+  z-index: 12;
+}
+#health-fill {
+  height: 100%;
+  width: 100%;
+  background: #f00;
+}
+


### PR DESCRIPTION
## Summary
- give each player a health pool on the server
- include health in snapshot packets
- display local health with a HUD bar
- allow boomerang hits on other players
- scale avatars' torsos based on remaining health
- periodically spawn damaging terrain spikes

## Testing
- `npm test` *(fails: Missing script)*
- `node --check server.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_685697c4101083269d218d6b4157c689