### PR TITLE
Add multi-spike terrain attack and player health labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
   <div id="shoot-button"></div>
 
   <div id="health-bar"><div id="health-fill"></div></div>
+  <div id="labels"></div>
 
   <!-- Three.js & Noise libs are imported by js/main.js -->
 

--- a/js/main.js
+++ b/js/main.js
@@ -161,6 +161,7 @@ const tmpVec      = new THREE.Vector3();
 const spikes      = [];                   // active terrain spikes
 const hitEffects  = [];                   // transient hit visuals
 const damageTimers= new Map();            // material → remaining flash time
+const labelContainer = document.getElementById('labels');
 let   prevMyHealth= MAX_HEALTH;
 
 let   myId        = null;
@@ -333,8 +334,8 @@ socket.addEventListener('message', e => {
     } break;
 
     case 'terrainSpike': {
-      const { x,z,r,delay } = msg;
-      spawnTerrainSpike(x, z, r, (delay||1000)/1000);
+      const { x,z,r,delay,h } = msg;
+      spawnTerrainSpike(x, z, r, (delay||1000)/1000, h);
     } break;
 
     case 'playerDied': {
@@ -578,9 +579,13 @@ function makeRemoteAvatar(col){
   hb.scale.set(1,0.1,1);
   hb.position.set(0,3.6,0);
   root.add(hb);
+  const label = document.createElement('div');
+  label.className = 'player-label';
+  label.textContent = MAX_HEALTH;
+  labelContainer.appendChild(label);
   root.userData={ body,head,Larm,Rarm,Lleg,Rleg, mat,
     boxGeo, octGeo:new THREE.OctahedronGeometry(1,0).rotateX(Math.PI/2),
-    healthBar:hb };
+    healthBar:hb, label };
   scene.add(root);
   ensureRemoteHasLoadedBullet(root,col);
   return root;
@@ -654,8 +659,20 @@ function makeRemoteAvatar(col){
     av.visible=true;
   }
   ghosts.forEach((av,id)=>{
-    if(!(id in pack)) av.visible=false;
-    av.userData.healthBar.lookAt(camera.position);
+    if(!(id in pack)){
+      av.visible=false;
+      av.userData.label.style.display = 'none';
+    } else {
+      av.userData.healthBar.lookAt(camera.position);
+      const pos = av.position.clone();
+      pos.y += 4;
+      pos.project(camera);
+      const sx = (pos.x * 0.5 + 0.5) * innerWidth;
+      const sy = (-pos.y * 0.5 + 0.5) * innerHeight;
+      av.userData.label.style.transform = `translate(-50%,-50%) translate(${sx}px,${sy}px)`;
+      av.userData.label.textContent = Math.round(av.userData.health ?? MAX_HEALTH);
+      av.userData.label.style.display = 'block';
+    }
   });
 
   /* ---------- remote bullets ---------- */
@@ -1047,10 +1064,10 @@ function updatePathMesh() {
   // path thickness tapers toward the destination – no arrows needed
 }
 
-function spawnTerrainSpike(x,z,r,delay){
+function spawnTerrainSpike(x,z,r,delay,height=1){
   const h = meshHeightAt(x,z);
-  const geo = new THREE.ConeGeometry(r*0.5,r*2,8);
-  const mat = new THREE.MeshStandardMaterial({ color:0x8844ff });
+  const geo = new THREE.ConeGeometry(r*0.5,r*2*height,8);
+  const mat = new THREE.MeshStandardMaterial({ color: terrain.material.color });
   const mesh = new THREE.Mesh(geo,mat);
   mesh.position.set(x,h,z);
   mesh.scale.y = 0.01;

--- a/server.js
+++ b/server.js
@@ -22,6 +22,7 @@ const TERRAIN_ATTACK_INTERVAL = 5000;
 const TERRAIN_ATTACK_RADIUS   = 3;
 const TERRAIN_SPIKE_DELAY     = 1000; // ms delay before damage applies
 const TERRAIN_DAMAGE = 25;
+const NUM_SPIKES_PER_ATTACK   = 5;
 
 /* ────────────────── GLOBAL STATE ──────────────────────── */
 // WebSocket server instance
@@ -87,22 +88,28 @@ setInterval(spawnTarget, 30000);
 
 function terrainAttack(){
   if(players.size===0) return;
-  const arr=[...players.values()];
-  const base=arr[Math.random()*arr.length|0].state;
-  const x=(base.x||0)+(Math.random()*6-3);
-  const z=(base.z||0)+(Math.random()*6-3);
-  const msg=JSON.stringify({
-    t:'terrainSpike', x, z, r:TERRAIN_ATTACK_RADIUS, delay:TERRAIN_SPIKE_DELAY
-  });
-  wss.clients.forEach(c=>c.readyState===1&&c.send(msg));
+  const spikes=[];
+  for(let i=0;i<NUM_SPIKES_PER_ATTACK;i++){
+    const x=(Math.random()*2-1)*TERRAIN_HALF;
+    const z=(Math.random()*2-1)*TERRAIN_HALF;
+    const h=0.5+Math.random()*2.5;
+    spikes.push({x,z,h});
+    const msg=JSON.stringify({
+      t:'terrainSpike', x, z, r:TERRAIN_ATTACK_RADIUS, delay:TERRAIN_SPIKE_DELAY, h
+    });
+    wss.clients.forEach(c=>c.readyState===1&&c.send(msg));
+  }
   setTimeout(()=>{
     for(const [id,p] of players){
-      const dx=(p.state.x||0)-x; const dz=(p.state.z||0)-z;
-      if(Math.hypot(dx,dz)<=TERRAIN_ATTACK_RADIUS){
-        p.health=Math.max(0,p.health-TERRAIN_DAMAGE);
-        if(p.health<=0){
-          wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id})));
-          p.health=MAX_HEALTH;
+      for(const s of spikes){
+        const dx=(p.state.x||0)-s.x; const dz=(p.state.z||0)-s.z;
+        if(Math.hypot(dx,dz)<=TERRAIN_ATTACK_RADIUS){
+          p.health=Math.max(0,p.health-TERRAIN_DAMAGE);
+          if(p.health<=0){
+            wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id})));
+            p.health=MAX_HEALTH;
+          }
+          break;
         }
       }
     }

--- a/styles/style.css
+++ b/styles/style.css
@@ -130,3 +130,22 @@ canvas {
   background: #f00;
 }
 
+#labels {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 30;
+}
+.player-label {
+  position: absolute;
+  color: white;
+  font-family: monospace;
+  font-size: 14px;
+  white-space: nowrap;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+


### PR DESCRIPTION
## Summary
- spawn multiple randomly sized spikes across the map
- color spikes to match the terrain
- show player health as floating text labels

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0b4838c832684ef8692688a037e