### PR TITLE
Refine spike attacks and hit detection

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -146,6 +146,7 @@ const NOISE_SCALE     = 0.004, NOISE_AMP = 30, NOISE_OCTS = 6;
 const TEXTURE_SIZE    = 256;               // resolution of procedural texture
 const MAX_DT          = 0.05;
 const MAX_HEALTH      = 100;
+const SPIKE_LIFE      = 0.3;               // seconds spike remains visible
 const mapSeed         = '🌎';                 // constant → identical terrain
 const noiseSky        = new SimplexNoise(mapSeed + 'sky');
 
@@ -782,11 +783,9 @@ function animate(now){
     if(p.owner===myId){
       ghosts.forEach((av,id)=>{
         if(hitPlayer) return;
-        const headPos = av.userData.head.getWorldPosition(new THREE.Vector3());
-        const bodyPos = av.userData.body.getWorldPosition(new THREE.Vector3());
-        const d = Math.min(p.mesh.position.distanceTo(headPos),
-                          p.mesh.position.distanceTo(bodyPos));
-        if(d<1){
+        const center = av.position.clone().add({x:0,y:1.5,z:0});
+        const d = p.mesh.position.distanceTo(center);
+        if(d < 1.5){
           socket.send(JSON.stringify({t:'hitPlayer', target:id, shotId:p.id}));
           flashMaterial(av.userData.mat);
           spawnHitEffect(av.position.clone());
@@ -844,13 +843,19 @@ function animate(now){
     const s=spikes[i];
     s.age += dt;
     if(s.age >= s.delay-0.5) s.disc.visible = true;
-    const ratio = THREE.MathUtils.clamp(s.age / s.delay, 0, 1);
-    s.spike.scale.y = Math.max(0.001, ratio);
-    if(s.age >= s.delay){
-      scene.remove(s.disc); s.disc.geometry.dispose(); s.disc.material.dispose();
-      scene.remove(s.spike); s.spike.geometry.dispose(); s.spike.material.dispose();
+    if(s.age >= s.delay && !s.triggered){
+      s.triggered = true;
+      s.triggerAge = 0;
+      s.spike.visible = true;
       deformTerrain(new THREE.Vector3(s.x,0,s.z), s.r, -DEFORM_DEPTH * s.height);
-      spikes.splice(i,1);
+    }
+    if(s.triggered){
+      s.triggerAge += dt;
+      if(s.triggerAge >= SPIKE_LIFE){
+        scene.remove(s.disc); s.disc.geometry.dispose(); s.disc.material.dispose();
+        scene.remove(s.spike); s.spike.geometry.dispose(); s.spike.material.dispose();
+        spikes.splice(i,1);
+      }
     }
   }
 
@@ -1063,12 +1068,12 @@ function spawnTerrainSpike(x,z,r,delay,height=1){
   const disc = new THREE.Mesh(baseGeo, baseMat);
   disc.rotation.x = -Math.PI/2;
   disc.position.set(x, y + 0.05, z);
-  disc.visible = false;
+  disc.visible = true;
   const spikeGeo = new THREE.CylinderGeometry(r*0.3, r*0.3, height, 6);
   const spikeMat = new THREE.MeshStandardMaterial({ color:0x883333 });
   const spike = new THREE.Mesh(spikeGeo, spikeMat);
   spike.position.set(x, y + height/2, z);
-  spike.scale.y = 0.001;
+  spike.visible = false;
   scene.add(disc);
   scene.add(spike);
   spikes.push({ x, z, r, delay, age:0, height, disc, spike });

--- a/server.js
+++ b/server.js
@@ -89,9 +89,17 @@ setInterval(spawnTarget, 30000);
 function terrainAttack(){
   if(players.size===0) return;
   const spikes=[];
+  const playerArr = [...players.values()];
   for(let i=0;i<NUM_SPIKES_PER_ATTACK;i++){
-    const x=(Math.random()*2-1)*TERRAIN_HALF;
-    const z=(Math.random()*2-1)*TERRAIN_HALF;
+    let x,z;
+    if(playerArr.length>0 && Math.random()<0.5){
+      const p = playerArr[Math.random()*playerArr.length|0];
+      x = p.state.x || 0;
+      z = p.state.z || 0;
+    }else{
+      x=(Math.random()*2-1)*TERRAIN_HALF;
+      z=(Math.random()*2-1)*TERRAIN_HALF;
+    }
     const h=2+Math.random()*6;
     spikes.push({x,z,h});
     const msg=JSON.stringify({


### PR DESCRIPTION
## Summary
- show only a red disc as the attack warning, spike appears when the attack hits
- broaden player hitboxes to include gaps between limbs
- occasionally aim terrain spikes at players on the server side

## Testing
- `npm test` *(fails: Missing script)*
- `node --check server.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6856a77ed5248326b1bcc74ac7a49e24