### PR TITLE
Reduce terrain spike frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ with `npm start` and connect.
 
 - Press the shoot button again to recall your boomerang early if it's already flying.
 - Hitting a floor target now restores a small amount of health instead of awarding score.
-- Random terrain strikes happen more frequently so keep moving!
+- Random terrain strikes now occur less often to reduce CPU load.
 - Spikes erupt from the ground before dealing damage so alert players can dodge.
 - Characters briefly flash red when hurt so you can tell a hit landed.

--- a/server.js
+++ b/server.js
@@ -18,11 +18,13 @@ const TERRAIN_HALF  = 100;
 const TARGET_RADIUS = 5;
 const MAX_HEALTH    = 100;
 const PROJECTILE_DAMAGE = 25;
-const TERRAIN_ATTACK_INTERVAL = 3000;
+// Base delay between terrain attacks (ms). Increased to lighten load
+const TERRAIN_ATTACK_INTERVAL = 6000;
 const TERRAIN_ATTACK_RADIUS   = 3;
 const TERRAIN_SPIKE_DELAY     = 1000; // ms delay before damage applies
 const TERRAIN_DAMAGE = 25;
-const NUM_SPIKES_PER_ATTACK   = 15;
+// Fewer spikes per attack for smoother gameplay
+const NUM_SPIKES_PER_ATTACK   = 8;
 
 /* ────────────────── GLOBAL STATE ──────────────────────── */
 // WebSocket server instance


### PR DESCRIPTION
## Summary
- spawn fewer spikes per terrain attack
- increase time between each terrain strike
- update README gameplay notes

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6856a9446b208326957c1e3f0459fc07