### PR TITLE
Expand hit detection and slow terrain attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ with `npm start` and connect.
 
 - Press the shoot button again to recall your boomerang early if it's already flying.
 - Hitting a floor target now restores a small amount of health instead of awarding score.
-- Random terrain strikes now occur less often to reduce CPU load.
+- Random terrain strikes now occur even less often to reduce CPU load.
 - Spikes erupt from the ground before dealing damage so alert players can dodge.
 - Characters briefly flash red when hurt so you can tell a hit landed.
+- Boomerang shots now register hits when striking any limb, not just the torso.

--- a/js/main.js
+++ b/js/main.js
@@ -783,9 +783,7 @@ function animate(now){
     if(p.owner===myId){
       ghosts.forEach((av,id)=>{
         if(hitPlayer) return;
-        const center = av.position.clone().add({x:0,y:1.5,z:0});
-        const d = p.mesh.position.distanceTo(center);
-        if(d < 1.5){
+        if(avatarHitTest(av,p.mesh.position)){
           socket.send(JSON.stringify({t:'hitPlayer', target:id, shotId:p.id}));
           flashMaterial(av.userData.mat);
           spawnHitEffect(av.position.clone());
@@ -1094,6 +1092,21 @@ function flashMaterial(mat){
   }
   damageTimers.set(mat,0.2);
   mat.emissive.set(0xff0000);
+}
+
+function avatarHitTest(av,pos){
+  const parts=[
+    [av.userData.head,0.7],
+    [av.userData.body,1.0],
+    [av.userData.Larm,0.4],[av.userData.Rarm,0.4],
+    [av.userData.Lleg,0.5],[av.userData.Rleg,0.5]
+  ];
+  const p=new THREE.Vector3();
+  for(const [mesh,r] of parts){
+    mesh.getWorldPosition(p);
+    if(p.distanceTo(pos)<=r) return true;
+  }
+  return false;
 }
 
 /* ─────────────────────────── HELPERS ─────────────────────────────── */

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ const TARGET_RADIUS = 5;
 const MAX_HEALTH    = 100;
 const PROJECTILE_DAMAGE = 25;
 // Base delay between terrain attacks (ms). Increased to lighten load
-const TERRAIN_ATTACK_INTERVAL = 6000;
+const TERRAIN_ATTACK_INTERVAL = 10000;
 const TERRAIN_ATTACK_RADIUS   = 3;
 const TERRAIN_SPIKE_DELAY     = 1000; // ms delay before damage applies
 const TERRAIN_DAMAGE = 25;


### PR DESCRIPTION
## Summary
- expand hit detection to consider limbs
- slow down the rate of terrain spike attacks
- document gameplay changes

## Testing
- `node --check server.js`
- `node --check js/main.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856aa9b1c5083268f26d98f147ea6bf