### PR TITLE
Reduce default render quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The terrain is now generated on the client using Simplex noise so no tile
 server or baking step is required. Simply start the web and WebSocket servers
 with `npm start` and connect.
 
+### Performance Options
+
+The renderer now caps pixel ratio at `0.75` and disables antialiasing by
+default. Adjust `PIXEL_RATIO_CAP` and `USE_ANTIALIAS` in `js/main.js` if you
+want to trade visual quality for higher frame rates.
+
 ### Gameplay
 
 - Press the shoot button again to recall your boomerang early if it's already flying.

--- a/js/main.js
+++ b/js/main.js
@@ -144,6 +144,8 @@ const MIN_RANGE_OUT   = MAX_OUT_RANGE, MAX_RANGE_OUT = MAX_OUT_RANGE * 2;
 const MIN_CRATER      = DEFORM_RADIUS, MAX_CRATER   = DEFORM_RADIUS * 3;
 const NOISE_SCALE     = 0.004, NOISE_AMP = 30, NOISE_OCTS = 6;
 const TEXTURE_SIZE    = 256;               // resolution of procedural texture
+const PIXEL_RATIO_CAP = 0.75;              // clamp resolution for perf
+const USE_ANTIALIAS   = false;             // disable AA to ease GPU load
 const MAX_DT          = 0.05;
 const MAX_HEALTH      = 100;
 const SPIKE_LIFE      = 0.3;               // seconds spike remains visible
@@ -251,8 +253,8 @@ sun.position.set(1,2,0.5).normalize();
 scene.add(sun);
 
 const camera   = new THREE.PerspectiveCamera(75, innerWidth/innerHeight, 0.1, 500);
-const renderer = new THREE.WebGLRenderer({ antialias:true });
-renderer.setPixelRatio(Math.min(devicePixelRatio,1));
+const renderer = new THREE.WebGLRenderer({ antialias: USE_ANTIALIAS });
+renderer.setPixelRatio(Math.min(devicePixelRatio, PIXEL_RATIO_CAP));
 renderer.setSize(innerWidth, innerHeight);
 document.body.appendChild(renderer.domElement);
   if (isMobile) setupMobileControls();


### PR DESCRIPTION
## Summary
- lower default pixel ratio and disable antialiasing to cut GPU usage
- document how to tweak these options

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6856aefb0334832696f419abaee08c2c