### PR TITLE
Disable terrain spike attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ want to trade visual quality for higher frame rates.
 
 - Press the shoot button again to recall your boomerang early if it's already flying.
 - Hitting a floor target now restores a small amount of health instead of awarding score.
-- Terrain spikes now occur roughly five random strikes per minute
-  with a targeted wave about once per minute.
-- Spikes erupt from the ground before dealing damage so alert players can dodge.
+- Terrain spikes are disabled by default. To re-enable them,
+  set `TERRAIN_ATTACKS_ENABLED` to `true` in `server.js`.
+- Spikes would normally erupt from the ground before dealing damage so alert players can dodge.
 - Characters briefly flash red when hurt so you can tell a hit landed.
 - Boomerang shots now register hits when striking any limb, not just the torso.

--- a/server.js
+++ b/server.js
@@ -28,6 +28,8 @@ const TERRAIN_SPIKE_DELAY      = 1000; // ms delay before damage applies
 const TERRAIN_DAMAGE           = 25;
 // Fewer spikes per attack for smoother gameplay
 const NUM_SPIKES_PER_ATTACK    = 2;
+// Toggle to completely disable terrain spike attacks
+const TERRAIN_ATTACKS_ENABLED  = false;
 
 /* ────────────────── GLOBAL STATE ──────────────────────── */
 // WebSocket server instance
@@ -150,8 +152,10 @@ function targetedTerrainAttack(){
   applySpikeDamage(spikes);
 }
 
-setInterval(randomTerrainAttack, RANDOM_ATTACK_INTERVAL);
-setInterval(targetedTerrainAttack, TARGETED_ATTACK_INTERVAL);
+if (TERRAIN_ATTACKS_ENABLED) {
+  setInterval(randomTerrainAttack, RANDOM_ATTACK_INTERVAL);
+  setInterval(targetedTerrainAttack, TARGETED_ATTACK_INTERVAL);
+}
 
 /* ─────────────── CLIENT CONNECTION ───────────────────── */
 // Handle new WebSocket connections


### PR DESCRIPTION
## Summary
- introduce `TERRAIN_ATTACKS_ENABLED` flag in `server.js`
- gate terrain spike intervals behind this flag
- update README instructions accordingly

## Testing
- `node --check server.js`
- `node --check js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_6856ba332e388326a3e0faf619c2503d