### PR TITLE
Add persistent power-ups

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -150,6 +150,9 @@ const MAX_DT          = 0.05;
 const MAX_HEALTH      = 100;
 const SPIKE_LIFE      = 0.3;               // seconds spike remains visible
 const HIT_PULL_RADIUS = 4.0;               // range for projectile attraction
+const SHIELD_DURATION = 10;
+const SPEED_DURATION  = 10;
+const DOUBLE_SHOTS    = 10;
 const mapSeed         = '🌎';                 // constant → identical terrain
 const noiseSky        = new SimplexNoise(mapSeed + 'sky');
 
@@ -166,6 +169,9 @@ const spikes      = [];                   // active terrain spikes
 const hitEffects  = [];                   // transient hit visuals
 const damageTimers= new Map();            // material → remaining flash time
 let   prevMyHealth= MAX_HEALTH;
+let   shieldTimer = 0;
+let   speedTimer  = 0;
+let   doubleShotsLeft = 0;
 
 let   myId        = null;
 let   myColor     = new THREE.Color(0x222222);
@@ -186,10 +192,10 @@ let   manualSprint = false, shiftHeld = false, joystickIntensity = 0;
 let   lastSpace = 0, lastZ = 0;
 const move = { f:0, b:0, l:0, r:0 };
 
-// ─────────── TARGET STATE ───────────
-let activeTarget   = null;   // { id, x, z }
+// ─────────── POWER-UP STATE ───────────
 const TARGET_RADIUS = 5;     // must match server’s radius
-let targetMesh     = null;   // Three.js mesh for the pillar/flag
+let powerups   = [];         // array of {id,x,z,type}
+const powerupMeshes = new Map();
 
 
 /* ──────────────────── DOM + RENDER TARGET SET-UP ─────────────────── */
@@ -299,26 +305,6 @@ socket.addEventListener('message', e => {
     case 'snapshot':
       applySnapshot(msg);
       break;
-    case 'newTarget': {
-    // server just spawned one
-    activeTarget = msg.target;            // { id, x, z }
-
-      // remove any old marker
-      if (targetMesh) {
-     scene.remove(targetMesh);
-      targetMesh.geometry.dispose();
-      targetMesh.material.dispose();
-    }
-
-    // create a simple pillar or flag at (x,z)
-    const height   = meshHeightAt(activeTarget.x, activeTarget.z);
-    const geom     = new THREE.CylinderGeometry(0.5,0.5, 3, 8);
-    const mat      = new THREE.MeshStandardMaterial({ color: 0xffff00 });
-    targetMesh     = new THREE.Mesh(geom, mat);
-    targetMesh.position.set(activeTarget.x, height + 1.5, activeTarget.z);
-    scene.add(targetMesh);
-    break;
-    }
 
     case 'crater': {
       const { x,z,r,d } = msg.crater;
@@ -508,19 +494,29 @@ function shootProjectile(){
   loadedBullet.position.copy(start).add(dir.clone().multiplyScalar(0.6));
   scene.add(loadedBullet);
 
-  projectiles.push({
-    mesh:loadedBullet, velocity:dir.clone().multiplyScalar(speedOut),
-    travelled:0, maxRange:rangeOut, craterRad:craterR,
-    returning:false, ttl:TTL_SECONDS, id:undefined,
-    owner: myId
-  });
-
-  if(socket.readyState===1&&myId){
-    socket.send(JSON.stringify({
-      t:'shot',
-      data:{ x:start.x,y:start.y,z:start.z, dir, c }
-    }));
+  const shots = doubleShotsLeft>0 ? 2 : 1;
+  for(let s=0;s<shots;s++){
+    const mesh = s===0 ? loadedBullet : loadedBullet.clone();
+    if(s===1) scene.add(mesh);
+    projectiles.push({
+      mesh,
+      velocity:dir.clone().multiplyScalar(speedOut),
+      travelled:0,
+      maxRange:rangeOut,
+      craterRad:craterR,
+      returning:false,
+      ttl:TTL_SECONDS,
+      id:undefined,
+      owner: myId
+    });
+    if(socket.readyState===1&&myId){
+      socket.send(JSON.stringify({
+        t:'shot',
+        data:{ x:start.x,y:start.y,z:start.z, dir, c }
+      }));
+    }
   }
+  if(doubleShotsLeft>0) doubleShotsLeft--;
   loadedBullet=null;
 }
 
@@ -584,7 +580,31 @@ function makeRemoteAvatar(col){
 }
 
 /* ────────────────────────── SNAPSHOT HANDLER ─────────────────────── */
-  function applySnapshot({ players:pack, projectiles:shots }){
+  function applySnapshot({ players:pack, projectiles:shots, powerups:pus }){
+  if(pus){
+    const seen=new Set();
+    pus.forEach(pu=>{
+      seen.add(pu.id);
+      if(!powerupMeshes.has(pu.id)){
+        const color = pu.type==='health'?0xffff00:
+                      pu.type==='double'?0x00ffff:
+                      pu.type==='shield'?0x00ff00:0xff00ff;
+        const geom=new THREE.CylinderGeometry(0.5,0.5,3,8);
+        const mat=new THREE.MeshStandardMaterial({color});
+        const mesh=new THREE.Mesh(geom,mat);
+        const h=meshHeightAt(pu.x,pu.z);
+        mesh.position.set(pu.x,h+1.5,pu.z);
+        scene.add(mesh); powerupMeshes.set(pu.id,mesh);
+      }
+    });
+    powerupMeshes.forEach((mesh,id)=>{
+      if(!seen.has(id)){
+        scene.remove(mesh); mesh.geometry.dispose(); mesh.material.dispose();
+        powerupMeshes.delete(id);
+      }
+    });
+    powerups = pus;
+  }
   if (pack[myId] && typeof pack[myId].health === 'number') {
     const newH = pack[myId].health;
     if(newH < prevMyHealth && bodyMesh){
@@ -599,6 +619,9 @@ function makeRemoteAvatar(col){
       bodyMesh.visible = scale > 0;
     }
     updateHealthBar();
+    shieldTimer = pack[myId].shield || 0;
+    speedTimer  = pack[myId].speed  || 0;
+    doubleShotsLeft = pack[myId].double || 0;
   }
 
   /* ---------- players ---------- */
@@ -748,6 +771,8 @@ function animate(now){
   if(!character || now-lastFrame<1000/60) return;
   lastFrame=now;
   const dt=Math.min(CLOCK.getDelta(),MAX_DT);
+  if(shieldTimer>0) shieldTimer=Math.max(0,shieldTimer-dt);
+  if(speedTimer>0) speedTimer=Math.max(0,speedTimer-dt);
 
   /* send raw input */
   if(socket.readyState===1&&myId){
@@ -795,20 +820,17 @@ function animate(now){
       }
     }
     if(hitGround){
-          if (hitGround && activeTarget) {
-      // see if we’re within radius of the active target
-      const dx = p.mesh.position.x - activeTarget.x;
-      const dz = p.mesh.position.z - activeTarget.z;
-      if (Math.hypot(dx, dz) <= TARGET_RADIUS) {
-        // first hit! tell the server
-        socket.send(JSON.stringify({
-          t: 'hitTarget',
-          targetId: activeTarget.id
-        }));
-        // clear locally so we only send once
-        activeTarget = null;
+      for(let i=0;i<powerups.length;i++){
+        const pu=powerups[i];
+        const dx=p.mesh.position.x-pu.x;
+        const dz=p.mesh.position.z-pu.z;
+        if(Math.hypot(dx,dz)<=TARGET_RADIUS){
+          socket.send(JSON.stringify({t:'pickup', powerupId:pu.id}));
+          const mesh=powerupMeshes.get(pu.id);
+          if(mesh){scene.remove(mesh); mesh.geometry.dispose(); mesh.material.dispose(); powerupMeshes.delete(pu.id);} 
+          powerups.splice(i,1); i--; 
+        }
       }
-    }
 
       deformTerrain(p.mesh.position.clone(),p.craterRad,DEFORM_DEPTH);
       if(socket.readyState===1&&myId){
@@ -892,7 +914,8 @@ function animate(now){
   if(dir.lengthSq()){
     dir.normalize().applyAxisAngle(new THREE.Vector3(0,1,0),yaw);
     const baseSpeed = flyMode ? 20 : 10;
-    const speedMult = isMobile ? 1 + joystickIntensity : (shiftHeld ? 2 : 1);
+    let speedMult = isMobile ? 1 + joystickIntensity : (shiftHeld ? 2 : 1);
+    if(speedTimer>0) speedMult *= 2;
     character.position.addScaledVector(dir, baseSpeed * speedMult * dt);
   }
 
@@ -1138,9 +1161,7 @@ function applyHitPull(p, dt){
       av.userData.body.getWorldPosition(tmpVec);
       test(tmpVec.clone());
     });
-    if(activeTarget && targetMesh){
-      test(targetMesh.position);
-    }
+    powerupMeshes.forEach(mesh=>{ test(mesh.position); });
   } else {
     if(headMesh){ headMesh.getWorldPosition(tmpVec); test(tmpVec.clone()); }
     if(bodyMesh){ bodyMesh.getWorldPosition(tmpVec); test(tmpVec.clone()); }

--- a/server.js
+++ b/server.js
@@ -31,6 +31,17 @@ const NUM_SPIKES_PER_ATTACK    = 2;
 // Toggle to completely disable terrain spike attacks
 const TERRAIN_ATTACKS_ENABLED  = false;
 
+// Power-up configuration
+const POWERUP_COUNTS = {
+  health: 10,
+  double: 5,
+  shield: 5,
+  speed: 5
+};
+const SHIELD_DURATION = 10; // seconds
+const SPEED_DURATION  = 10; // seconds
+const DOUBLE_SHOTS    = 10; // number of double shots
+
 /* ────────────────── GLOBAL STATE ──────────────────────── */
 // WebSocket server instance
 const wss = new WebSocketServer({ port: PORT });
@@ -40,8 +51,8 @@ const players = new Map();
 const projectiles = [];
 // Running ID for each new shot
 let nextShotId = 0;
-// Current active target (or null if none)
-let activeTarget = null;
+// Power-ups present in the world
+let powerups = [];
 
 /* ──────────── NAMED COLOR PALETTE ────────────────────── */
 // A set of high-contrast color names
@@ -67,31 +78,40 @@ function pickNamedColour() {
 function packSnapshot() {
   return JSON.stringify({
     t: 'snapshot',
-    // players: id → { x,y,z,yaw,pitch,flyMode,color }
     players: Object.fromEntries(
       [...players.entries()].map(([id,p]) => [
         id,
-        { ...p.state, color: p.color, health: p.health }
+        {
+          ...p.state,
+          color: p.color,
+          health: p.health,
+          shield: p.shield || 0,
+          speed: p.speed || 0,
+          double: p.doubleShots || 0
+        }
       ])
     ),
-    // array of projectile records
-    projectiles
+    projectiles,
+    powerups
   });
 }
 
-/* ───────────── TARGET SPAWNING & BROADCAST ───────────── */
-// Create a new target somewhere in the world and notify all clients
-function spawnTarget() {
-  const id = uuid();
-  const x  = (Math.random()*2 - 1) * TERRAIN_HALF;
-  const z  = (Math.random()*2 - 1) * TERRAIN_HALF;
-  activeTarget = { id, x, z };
-  const msg = JSON.stringify({ t:'newTarget', target: activeTarget });
-  wss.clients.forEach(c => c.readyState===1 && c.send(msg));
+/* ───────────── POWER-UP SPAWNING ───────────── */
+function spawnInitialPowerups(){
+  powerups = [];
+  for(const [type,count] of Object.entries(POWERUP_COUNTS)){
+    for(let i=0;i<count;i++){
+      powerups.push({
+        id: uuid(),
+        type,
+        x: (Math.random()*2-1)*TERRAIN_HALF,
+        z: (Math.random()*2-1)*TERRAIN_HALF
+      });
+    }
+  }
 }
-// First spawn in 2s, then every 30s
-setTimeout(spawnTarget, 2000);
-setInterval(spawnTarget, 30000);
+// Spawn once on startup
+spawnInitialPowerups();
 
 function sendSpike(x, z, h){
   const msg = JSON.stringify({
@@ -112,6 +132,7 @@ function applySpikeDamage(spikes){
         const dz=(p.state.z||0)-s.z;
         const dy=(p.state.y||0);
         if(Math.hypot(dx,dz)<=TERRAIN_ATTACK_RADIUS && dy<=s.h+2){
+          if(p.shield>0) break;
           p.health=Math.max(0,p.health-TERRAIN_DAMAGE);
           if(p.health<=0){
             wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id}))); 
@@ -165,7 +186,15 @@ wss.on('connection', ws => {
   const color = pickNamedColour();
 
   // Initialize player state
-  players.set(id, { input:{}, state:{}, color, health: MAX_HEALTH });
+  players.set(id, {
+    input:{},
+    state:{},
+    color,
+    health: MAX_HEALTH,
+    shield: 0,
+    speed: 0,
+    doubleShots: 0
+  });
 
   // Send welcome packet with assigned ID, color, and noise seed
   ws.send(JSON.stringify({ t:'welcome', id, color, seed: NOISE_SEED }));
@@ -214,13 +243,27 @@ wss.on('connection', ws => {
         });
         break;
 
-      // Client reports hitting the active target
-      case 'hitTarget': {
-        if (activeTarget && msg.targetId === activeTarget.id) {
+      // Client reports picking up a power-up
+      case 'pickup': {
+        const idx = powerups.findIndex(pu => pu.id === msg.powerupId);
+        if (idx !== -1) {
+          const item = powerups[idx];
+          powerups.splice(idx,1);
           const p = players.get(id);
-          p.health = Math.min(MAX_HEALTH, p.health + 20);
-          activeTarget = null;
-          spawnTarget();
+          switch(item.type){
+            case 'health':
+              p.health = Math.min(MAX_HEALTH, p.health + 20);
+              break;
+            case 'double':
+              p.doubleShots = DOUBLE_SHOTS;
+              break;
+            case 'shield':
+              p.shield = SHIELD_DURATION;
+              break;
+            case 'speed':
+              p.speed = SPEED_DURATION;
+              break;
+          }
         }
         break;
       }
@@ -228,6 +271,7 @@ wss.on('connection', ws => {
       case 'hitPlayer': {
         const target = players.get(msg.target);
         if (target) {
+          if (target.shield > 0) break;
           const idx = projectiles.findIndex(p => p.id===msg.shotId);
           let mult = 1;
           if (idx !== -1) {
@@ -269,6 +313,11 @@ setInterval(() => {
   for (let i = projectiles.length-1; i>=0; i--) {
     projectiles[i].ttl -= dt;
     if (projectiles[i].ttl <= 0) projectiles.splice(i,1);
+  }
+  // Update player effect timers
+  for(const p of players.values()){
+    if(p.shield>0) p.shield = Math.max(0, p.shield - dt);
+    if(p.speed>0) p.speed = Math.max(0, p.speed - dt);
   }
   // Broadcast world snapshot
   const packet = packSnapshot();


### PR DESCRIPTION
## Summary
- scatter power-up items across terrain on startup
- track each player's shield, speed, and double shot timers
- add power-up pickup logic and syncing
- implement double-shot, shield, and speed boost effects

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856c82ebe9483269566c88699e0c28f