### PR TITLE
Visual power-ups as discs on terrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ want to trade visual quality for higher frame rates.
 ### Gameplay
 
 - Press the shoot button again to recall your boomerang early if it's already flying.
-- Hitting a floor target now restores a small amount of health instead of awarding score.
+- Hitting a floor target now restores a small amount of health instead of awarding score. Targets appear as colored discs on the ground.
 - Terrain spikes are disabled by default. To re-enable them,
   set `TERRAIN_ATTACKS_ENABLED` to `true` in `server.js`.
 - Spikes would normally erupt from the ground before dealing damage so alert players can dodge.

--- a/js/main.js
+++ b/js/main.js
@@ -589,11 +589,12 @@ function makeRemoteAvatar(col){
         const color = pu.type==='health'?0xffff00:
                       pu.type==='double'?0x00ffff:
                       pu.type==='shield'?0x00ff00:0xff00ff;
-        const geom=new THREE.CylinderGeometry(0.5,0.5,3,8);
-        const mat=new THREE.MeshStandardMaterial({color});
-        const mesh=new THREE.Mesh(geom,mat);
-        const h=meshHeightAt(pu.x,pu.z);
-        mesh.position.set(pu.x,h+1.5,pu.z);
+        const geom = new THREE.CircleGeometry(0.75, 16);
+        const mat  = new THREE.MeshBasicMaterial({ color, side:THREE.DoubleSide });
+        const mesh = new THREE.Mesh(geom, mat);
+        mesh.rotation.x = -Math.PI/2;
+        const h = meshHeightAt(pu.x, pu.z);
+        mesh.position.set(pu.x, h + 0.05, pu.z);
         scene.add(mesh); powerupMeshes.set(pu.id,mesh);
       }
     });


### PR DESCRIPTION
## Summary
- draw power-ups as flat discs instead of tall cylinders
- note disc-shaped floor targets in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856cb22c514832690245904074b7c2c