### PR TITLE
Add round system and leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
 
   <div id="health-bar"><div id="health-fill"></div></div>
   <div id="labels"></div>
+  <div id="leaderboard"></div>
 
   <!-- Three.js & Noise libs are imported by js/main.js -->
 

--- a/js/main.js
+++ b/js/main.js
@@ -147,7 +147,7 @@ const TEXTURE_SIZE    = 256;               // resolution of procedural texture
 const PIXEL_RATIO_CAP = 0.75;              // clamp resolution for perf
 const USE_ANTIALIAS   = true;              // enable antialiasing
 const MAX_DT          = 0.05;
-const MAX_HEALTH      = 100;
+const MAX_HEALTH      = 150;
 const SPIKE_LIFE      = 0.3;               // seconds spike remains visible
 const HIT_PULL_RADIUS = 4.0;               // range for projectile attraction
 const SHIELD_DURATION = 10;
@@ -172,10 +172,12 @@ let   prevMyHealth= MAX_HEALTH;
 let   shieldTimer = 0;
 let   speedTimer  = 0;
 let   doubleShotsLeft = 0;
+let   isDead      = false;
 
 let   myId        = null;
 let   myColor     = new THREE.Color(0x222222);
 let   myHealth    = MAX_HEALTH;
+const leaderboardEl = document.getElementById('leaderboard');
 
 function updateHealthBar() {
   const fill = document.getElementById('health-fill');
@@ -323,7 +325,21 @@ socket.addEventListener('message', e => {
     case 'playerDied': {
       if (msg.id === myId) {
         teleport();
+        isDead = true;
       }
+    } break;
+
+    case 'roundEnd': {
+      if (leaderboardEl) {
+        const rows = msg.board.map((b,i)=>`${i+1}. <span style="color:${b.color}">${b.color}</span> - ${b.kills}`).join('<br>');
+        leaderboardEl.innerHTML = `<h3>Round Over</h3>${rows}`;
+        leaderboardEl.style.display = 'block';
+      }
+    } break;
+
+    case 'roundStart': {
+      isDead = false;
+      if (leaderboardEl) leaderboardEl.style.display = 'none';
     } break;
   }
 });
@@ -476,7 +492,7 @@ function spawnLoadedBullet(){
   character.add(loadedBullet);
 }
 function shootProjectile(){
-  if(!loadedBullet) return;
+  if(!loadedBullet || isDead) return;
   const c=currentCharge;
   const speedOut=THREE.MathUtils.lerp(MIN_SPEED_OUT,MAX_SPEED_OUT,c);
   const rangeOut=THREE.MathUtils.lerp(MIN_RANGE_OUT,MAX_RANGE_OUT,c);
@@ -521,6 +537,7 @@ function shootProjectile(){
 }
 
 function recallProjectile(){
+  if(isDead) return;
   if(loadedBullet){
     charging = false;
     currentCharge = 0;
@@ -614,6 +631,7 @@ function makeRemoteAvatar(col){
     }
     myHealth = newH;
     prevMyHealth = newH;
+    if(myHealth>0) isDead = false;
     const scale = Math.max(0, myHealth / MAX_HEALTH);
     if (bodyMesh) {
       bodyMesh.scale.y = scale;
@@ -774,9 +792,13 @@ function animate(now){
   const dt=Math.min(CLOCK.getDelta(),MAX_DT);
   if(shieldTimer>0) shieldTimer=Math.max(0,shieldTimer-dt);
   if(speedTimer>0) speedTimer=Math.max(0,speedTimer-dt);
+  if(isDead){
+    renderer.render(scene,camera);
+    return;
+  }
 
   /* send raw input */
-  if(socket.readyState===1&&myId){
+  if(socket.readyState===1&&myId&&!isDead){
     socket.send(JSON.stringify({ t:'input',
       input:{ move,spaceHeld,zHeld ,shiftHeld }}));
   }

--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ const NOISE_SEED = 'sig-terrain-v1';
 // Bounds for where targets can spawn
 const TERRAIN_HALF  = 100;
 const TARGET_RADIUS = 5;
-const MAX_HEALTH    = 100;
+const MAX_HEALTH    = 150;
 const PROJECTILE_DAMAGE = 25;
 // Base delay between terrain attacks (ms). Increased to lighten load
 // Random spikes occur roughly five times per minute while
@@ -49,6 +49,8 @@ const wss = new WebSocketServer({ port: PORT });
 const players = new Map();
 // Array of active boomerang projectiles
 const projectiles = [];
+// Round length (ms)
+const ROUND_LENGTH_MS = 180000; // 3 minutes
 // Running ID for each new shot
 let nextShotId = 0;
 // Power-ups present in the world
@@ -110,8 +112,35 @@ function spawnInitialPowerups(){
     }
   }
 }
-// Spawn once on startup
-spawnInitialPowerups();
+
+let roundTimer = null;
+
+function startRound(){
+  spawnInitialPowerups();
+  for(const p of players.values()){
+    p.health = MAX_HEALTH;
+    p.dead = false;
+    p.kills = 0;
+  }
+  wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'roundStart'})));
+  scheduleRoundEnd();
+}
+
+function endRound(){
+  const board=[...players.values()].map(p=>({color:p.color,kills:p.kills||0}))
+    .sort((a,b)=>b.kills-a.kills);
+  wss.clients.forEach(c=>c.readyState===1&&
+    c.send(JSON.stringify({t:'roundEnd',board})));
+  setTimeout(startRound,5000);
+}
+
+function scheduleRoundEnd(){
+  clearTimeout(roundTimer);
+  roundTimer=setTimeout(endRound,ROUND_LENGTH_MS);
+}
+
+// Start first round
+startRound();
 
 function sendSpike(x, z, h){
   const msg = JSON.stringify({
@@ -134,9 +163,9 @@ function applySpikeDamage(spikes){
         if(Math.hypot(dx,dz)<=TERRAIN_ATTACK_RADIUS && dy<=s.h+2){
           if(p.shield>0) break;
           p.health=Math.max(0,p.health-TERRAIN_DAMAGE);
-          if(p.health<=0){
-            wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id}))); 
-            p.health=MAX_HEALTH;
+          if(p.health<=0 && !p.dead){
+            p.dead = true;
+            wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id})));
           }
           break;
         }
@@ -193,7 +222,9 @@ wss.on('connection', ws => {
     health: MAX_HEALTH,
     shield: 0,
     speed: 0,
-    doubleShots: 0
+    doubleShots: 0,
+    kills: 0,
+    dead: false
   });
 
   // Send welcome packet with assigned ID, color, and noise seed
@@ -203,6 +234,10 @@ wss.on('connection', ws => {
   ws.on('message', raw => {
     let msg;
     try { msg = JSON.parse(raw); } catch { return; }
+
+    const me = players.get(id);
+    if(!me) return;
+    if(me.dead && msg.t !== 'input' && msg.t !== 'state') return;
 
     switch (msg.t) {
 
@@ -270,21 +305,23 @@ wss.on('connection', ws => {
 
       case 'hitPlayer': {
         const target = players.get(msg.target);
-        if (target) {
+        if (target && !target.dead) {
           if (target.shield > 0) break;
           const idx = projectiles.findIndex(p => p.id===msg.shotId);
           let mult = 1;
           if (idx !== -1) {
             const proj = projectiles[idx];
             mult = 1 + 2 * (proj.c ?? 0);
+            const killer = players.get(proj.owner);
             projectiles.splice(idx,1);
+            if(killer) killer.kills = (killer.kills||0)+1;
           }
           const dmg = PROJECTILE_DAMAGE * mult;
           target.health = Math.max(0, target.health - dmg);
           if (target.health <= 0) {
+            target.dead = true;
             wss.clients.forEach(c => c.readyState===1 &&
               c.send(JSON.stringify({ t:'playerDied', id: msg.target })));
-            target.health = MAX_HEALTH;
           }
         }
         break;

--- a/styles/style.css
+++ b/styles/style.css
@@ -149,3 +149,19 @@ canvas {
   pointer-events: none;
 }
 
+#leaderboard {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0,0,0,0.7);
+  color: white;
+  padding: 20px;
+  border: 1px solid #fff;
+  border-radius: 8px;
+  font-family: monospace;
+  display: none;
+  z-index: 1000;
+  text-align: center;
+}
+


### PR DESCRIPTION
## Summary
- increase player health to 150
- implement timed rounds with kill tracking on the server
- add round start/end events and leaderboard overlay in the client
- stop movement and shooting when dead

## Testing
- `node --check server.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6856cd479efc83269d5e666e7d5f8972