### PR TITLE
Add lives-based respawns

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,27 +13,7 @@
 </head>
 <body>
 
-  <div id="info">
-    <strong>Controls:</strong>
-    <span id="controls-desktop">
-      W/A/S/D → Move<br>
-      Mouse → Look<br>
-      Shift → Sprint<br>
-      Space ↔ Fly Mode<br>
-      Ctrl → Descend<br>
-      LMB → Shoot / Recall<br>
-      Esc → Reset
-    </span>
-    <span id="controls-mobile" style="display: none;">
-      Joystick (left) → Move<br>
-      Drag screen → Look<br>
-      Red Button → Shoot / Recall<br>
-      Tap top or ▲ ↔ Jump / Ascend<br>
-      Tap bottom or ▼ ↔ Descend<br>
-      Fly Btn ↔ Fly / Walk<br>
-      ⛶ → Fullscreen
-    </span>
-  </div>
+
 
 
   <button id="fullscreen-btn">⛶</button>
@@ -46,31 +26,17 @@
 
   <!-- Three.js & Noise libs are imported by js/main.js -->
 
-  <!-- Mobile UI behavior (joystick, fullscreen hints, fly/jump) -->
+  <!-- Mobile UI behavior (joystick and fullscreen) -->
   <script>
     const isMobile      = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-    const infoPanel     = document.getElementById('info');
     const fullscreenBtn = document.getElementById('fullscreen-btn');
-    let idleTimeout;
-
-    function resetIdleTimer() {
-      infoPanel.classList.remove('visible');
-      fullscreenBtn.classList.remove('visible');
-      clearTimeout(idleTimeout);
-      idleTimeout = setTimeout(() => {
-        infoPanel.classList.add('visible');
-        fullscreenBtn.classList.add('visible');
-      }, 3000);
-    }
 
     window.addEventListener('DOMContentLoaded', () => {
       if (!isMobile) return;
 
-      document.getElementById('controls-desktop').style.display   = 'none';
-      document.getElementById('controls-mobile').style.display    = 'inline';
-      document.getElementById('joystick-zone').style.display      = 'block';
-      document.getElementById('shoot-button').style.display       = 'block';
-      fullscreenBtn.style.display                                 = 'block';
+      document.getElementById('joystick-zone').style.display = 'block';
+      document.getElementById('shoot-button').style.display  = 'block';
+      fullscreenBtn.style.display                             = 'block';
 
       fullscreenBtn.addEventListener('click', () => {
         const el = document.documentElement;
@@ -80,10 +46,6 @@
           document.exitFullscreen?.() || document.webkitExitFullscreen?.();
         }
       });
-
-      document.addEventListener('touchstart', resetIdleTimer, { passive: true });
-      document.addEventListener('mousemove', resetIdleTimer, { passive: true });
-      resetIdleTimer();
     });
   </script>
 

--- a/js/main.js
+++ b/js/main.js
@@ -153,6 +153,7 @@ const HIT_PULL_RADIUS = 4.0;               // range for projectile attraction
 const SHIELD_DURATION = 10;
 const SPEED_DURATION  = 10;
 const DOUBLE_SHOTS    = 10;
+const START_LIVES     = 5;
 const mapSeed         = '🌎';                 // constant → identical terrain
 const noiseSky        = new SimplexNoise(mapSeed + 'sky');
 
@@ -176,6 +177,7 @@ let   doubleShotsLeft = 0;
 let   myId        = null;
 let   myColor     = new THREE.Color(0x222222);
 let   myHealth    = MAX_HEALTH;
+let   myLives     = START_LIVES;
 
 function updateHealthBar() {
   const fill = document.getElementById('health-fill');
@@ -269,18 +271,7 @@ document.body.appendChild(renderer.domElement);
 /* directional paths to other players */
 const playerPathMeshes = new Map();
 
-/* simple “idle controls” overlay fade */
-const infoEl     = document.getElementById('info');
-let   showTimer  = null;
-['mousemove','mousedown','keydown','touchstart'].forEach(evt =>
-  document.addEventListener(evt, () => {
-    infoEl.style.opacity = '0';
-    clearTimeout(showTimer);
-    showTimer = setTimeout(() => {
-      infoEl.style.opacity = '1';
-    }, 10000);
-  }, { passive:true })
-);
+
 
 /* ──────────────────────────── SOCKET I/O ─────────────────────────── */
 socket.addEventListener('message', e => {
@@ -323,6 +314,17 @@ socket.addEventListener('message', e => {
     case 'playerDied': {
       if (msg.id === myId) {
         teleport();
+      }
+    } break;
+
+    case 'playerOut': {
+      const av = ghosts.get(msg.id);
+      if (av) {
+        scene.remove(av);
+        ghosts.delete(msg.id);
+      }
+      if (msg.id === myId) {
+        alert('Game over!');
       }
     } break;
   }
@@ -607,6 +609,9 @@ function makeRemoteAvatar(col){
     powerups = pus;
   }
   if (pack[myId] && typeof pack[myId].health === 'number') {
+    if (typeof pack[myId].lives === 'number') {
+      myLives = pack[myId].lives;
+    }
     const newH = pack[myId].health;
     if(newH < prevMyHealth && bodyMesh){
       flashMaterial(bodyMesh.material);
@@ -633,6 +638,7 @@ function makeRemoteAvatar(col){
     av.position.set(st.x,st.y,st.z);
     av.rotation.y = st.yaw;
     av.userData.mat.color.set(st.color);
+    if (typeof st.lives === 'number') av.userData.lives = st.lives;
 
     if (typeof st.health === 'number') {
       if(av.userData.lastHealth!==undefined && st.health < av.userData.lastHealth){

--- a/server.js
+++ b/server.js
@@ -41,6 +41,7 @@ const POWERUP_COUNTS = {
 const SHIELD_DURATION = 10; // seconds
 const SPEED_DURATION  = 10; // seconds
 const DOUBLE_SHOTS    = 10; // number of double shots
+const START_LIVES     = 5;  // lives per player
 
 /* ────────────────── GLOBAL STATE ──────────────────────── */
 // WebSocket server instance
@@ -87,7 +88,8 @@ function packSnapshot() {
           health: p.health,
           shield: p.shield || 0,
           speed: p.speed || 0,
-          double: p.doubleShots || 0
+          double: p.doubleShots || 0,
+          lives: p.lives
         }
       ])
     ),
@@ -135,8 +137,16 @@ function applySpikeDamage(spikes){
           if(p.shield>0) break;
           p.health=Math.max(0,p.health-TERRAIN_DAMAGE);
           if(p.health<=0){
-            wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id}))); 
-            p.health=MAX_HEALTH;
+            p.lives -= 1;
+            if(p.lives>0){
+              wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id})));
+              p.health=MAX_HEALTH;
+            } else {
+              wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerOut',id})));
+              usedColors.delete(p.color);
+              players.delete(id);
+              break;
+            }
           }
           break;
         }
@@ -193,7 +203,8 @@ wss.on('connection', ws => {
     health: MAX_HEALTH,
     shield: 0,
     speed: 0,
-    doubleShots: 0
+    doubleShots: 0,
+    lives: START_LIVES
   });
 
   // Send welcome packet with assigned ID, color, and noise seed
@@ -282,9 +293,17 @@ wss.on('connection', ws => {
           const dmg = PROJECTILE_DAMAGE * mult;
           target.health = Math.max(0, target.health - dmg);
           if (target.health <= 0) {
-            wss.clients.forEach(c => c.readyState===1 &&
-              c.send(JSON.stringify({ t:'playerDied', id: msg.target })));
-            target.health = MAX_HEALTH;
+            target.lives -= 1;
+            if (target.lives > 0) {
+              wss.clients.forEach(c => c.readyState===1 &&
+                c.send(JSON.stringify({ t:'playerDied', id: msg.target })));
+              target.health = MAX_HEALTH;
+            } else {
+              wss.clients.forEach(c => c.readyState===1 &&
+                c.send(JSON.stringify({ t:'playerOut', id: msg.target })));
+              usedColors.delete(target.color);
+              players.delete(msg.target);
+            }
           }
         }
         break;

--- a/styles/style.css
+++ b/styles/style.css
@@ -18,24 +18,7 @@ canvas {
   touch-action: none;
 }
 
-/* Idle-hint panel */
-#info {
-  position: absolute;
-  top: 10px; left: 10px;
-  background: rgba(0,0,0,0.6);
-  color: #fff;
-  padding: 8px;
-  font-family: monospace;
-  font-size: 13px;
-  border-radius: 4px;
-  pointer-events: none;
-  z-index: 100;
-  opacity: 0;
-  transition: opacity 0.8s ease;
-}
-.visible {
-  opacity: 1 !important;
-}
+
 
 
 


### PR DESCRIPTION
## Summary
- convert game to last man standing with five lives each
- remove control overlay styles and logic
- clean up mobile UI script
- handle player eliminations on the server

## Testing
- `npm --version`
- `node -v`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856d9ab993c8326922bab308d9d390a