### PR TITLE
Show remaining lives and add spectator mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,10 @@
   <div id="joystick-look-zone"></div>
   <div id="shoot-button"></div>
 
-  <div id="health-bar"><div id="health-fill"></div></div>
+  <div id="health-bar">
+    <div id="life-count"></div>
+    <div id="health-fill"></div>
+  </div>
   <div id="labels"></div>
 
   <!-- Three.js & Noise libs are imported by js/main.js -->

--- a/js/main.js
+++ b/js/main.js
@@ -178,10 +178,19 @@ let   myId        = null;
 let   myColor     = new THREE.Color(0x222222);
 let   myHealth    = MAX_HEALTH;
 let   myLives     = START_LIVES;
+let   spectator   = false;
 
 function updateHealthBar() {
   const fill = document.getElementById('health-fill');
   if (fill) fill.style.width = `${myHealth}%`;
+}
+
+function updateLivesDisplay() {
+  const el = document.getElementById('life-count');
+  if (el) {
+    el.textContent = myLives;
+    el.style.color = myColor.getStyle();
+  }
 }
 let   character, bodyMesh, headMesh, Larm, Rarm, Lleg, Rleg;
 let   boxGeo, octGeo, bulletMat, loadedBullet = null;
@@ -281,6 +290,8 @@ socket.addEventListener('message', e => {
     case 'welcome':
       myId    = msg.id;
       myColor = new THREE.Color().setStyle(msg.color);
+      myLives = START_LIVES;
+      updateLivesDisplay();
 
       // Update avatar colors if we've already built the character
       if (bodyMesh) {
@@ -324,7 +335,9 @@ socket.addEventListener('message', e => {
         ghosts.delete(msg.id);
       }
       if (msg.id === myId) {
-        alert('Game over!');
+        alert('Game over! You are now spectating.');
+        spectator = true;
+        if (character) scene.remove(character);
       }
     } break;
   }
@@ -335,6 +348,7 @@ noise = new SimplexNoise(mapSeed);
 initTerrain().then(() => {
   initCharacter();
   updateHealthBar();
+  updateLivesDisplay();
   requestAnimationFrame(animate);
 });
 
@@ -478,6 +492,7 @@ function spawnLoadedBullet(){
   character.add(loadedBullet);
 }
 function shootProjectile(){
+  if (spectator) return;
   if(!loadedBullet) return;
   const c=currentCharge;
   const speedOut=THREE.MathUtils.lerp(MIN_SPEED_OUT,MAX_SPEED_OUT,c);
@@ -523,6 +538,7 @@ function shootProjectile(){
 }
 
 function recallProjectile(){
+  if (spectator) return;
   if(loadedBullet){
     charging = false;
     currentCharge = 0;
@@ -611,6 +627,7 @@ function makeRemoteAvatar(col){
   if (pack[myId] && typeof pack[myId].health === 'number') {
     if (typeof pack[myId].lives === 'number') {
       myLives = pack[myId].lives;
+      updateLivesDisplay();
     }
     const newH = pack[myId].health;
     if(newH < prevMyHealth && bodyMesh){
@@ -721,6 +738,7 @@ function makeRemoteAvatar(col){
     remoteShots.set(s.id,true);
   });
   updatePlayerPathMeshes();
+  updateRemoteLabels();
 }
 
 /* ────────────────────────── INPUT HANDLERS ───────────────────────── */
@@ -990,12 +1008,10 @@ function animate(now){
   if (skyMesh) {
   skyMesh.position.copy(camera.position);
 }
-
-
   renderer.render(scene,camera);
 
   updatePlayerPathMeshes();
-
+  updateRemoteLabels();
 
 }
 window.addEventListener('resize',()=>{
@@ -1092,6 +1108,32 @@ function updatePlayerPathMeshes() {
     );
     scene.add(mesh);
     playerPathMeshes.set(id, mesh);
+  });
+}
+
+function updateRemoteLabels() {
+  const container = document.getElementById('labels');
+  if (!container) return;
+  ghosts.forEach((av, id) => {
+    let label = av.userData.label;
+    if (!label) {
+      label = document.createElement('div');
+      label.className = 'player-label';
+      container.appendChild(label);
+      av.userData.label = label;
+    }
+    if (!av.visible) {
+      label.style.display = 'none';
+      return;
+    }
+    label.style.display = 'block';
+    label.textContent = av.userData.lives ?? START_LIVES;
+    label.style.color = av.userData.mat.color.getStyle();
+    const pos = av.userData.head.getWorldPosition(new THREE.Vector3());
+    pos.project(camera);
+    const x = (pos.x * 0.5 + 0.5) * innerWidth;
+    const y = (-pos.y * 0.5 + 0.5) * innerHeight - 40;
+    label.style.transform = `translate(-50%, -50%) translate(${x}px,${y}px)`;
   });
 }
 

--- a/server.js
+++ b/server.js
@@ -219,16 +219,17 @@ wss.on('connection', ws => {
 
       // Raw input (movement/keys) from client
       case 'input':
-        players.get(id).input = msg.input;
+        if (players.has(id)) players.get(id).input = msg.input;
         break;
 
       // Client's current pose/state
       case 'state':
-        players.get(id).state = msg.state;
+        if (players.has(id)) players.get(id).state = msg.state;
         break;
 
       // A new boomerang shot fired
       case 'shot': {
+        if (!players.has(id)) break;
         const { x,y,z,dir,c } = msg.data;
         projectiles.push({
           id: nextShotId++,
@@ -241,6 +242,7 @@ wss.on('connection', ws => {
 
       // Client caught or despawned one of their own shots
       case 'catch': {
+        if (!players.has(id)) break;
         const idx = projectiles.findIndex(p => p.id===msg.shotId);
         if (idx !== -1) projectiles.splice(idx,1);
         break;
@@ -256,6 +258,7 @@ wss.on('connection', ws => {
 
       // Client reports picking up a power-up
       case 'pickup': {
+        if (!players.has(id)) break;
         const idx = powerups.findIndex(pu => pu.id === msg.powerupId);
         if (idx !== -1) {
           const item = powerups[idx];
@@ -280,6 +283,7 @@ wss.on('connection', ws => {
       }
 
       case 'hitPlayer': {
+        if (!players.has(id)) break;
         const target = players.get(msg.target);
         if (target) {
           if (target.shield > 0) break;

--- a/styles/style.css
+++ b/styles/style.css
@@ -107,6 +107,15 @@ canvas {
   border-radius: 4px;
   z-index: 12;
 }
+#life-count {
+  position: absolute;
+  top: -18px;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  font-family: monospace;
+  pointer-events: none;
+}
 #health-fill {
   height: 100%;
   width: 100%;


### PR DESCRIPTION
## Summary
- show a "life-count" display above the health bar
- track remaining lives in the client and update UI
- render each remote player's lives via DOM labels
- disable shooting/recall when spectating
- enter spectator mode after all lives are lost
- harden server against messages from spectators

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856de7660e083268d33e963b1ad39df