### PR TITLE
Disable path lines when player has no lives

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1075,8 +1075,28 @@ function createPathStrip(from, to, startWidth = 1, endWidth = 0.5,
 
 function updatePlayerPathMeshes() {
   if (!terrain || !character || !bodyMesh) return;
+  if (spectator || myLives <= 0) {
+    playerPathMeshes.forEach(mesh => {
+      scene.remove(mesh);
+      mesh.geometry.dispose();
+      mesh.material.dispose();
+    });
+    playerPathMeshes.clear();
+    return;
+  }
   ghosts.forEach((av, id) => {
     if (!av.visible) {
+      const old = playerPathMeshes.get(id);
+      if (old) {
+        scene.remove(old);
+        old.geometry.dispose();
+        old.material.dispose();
+        playerPathMeshes.delete(id);
+      }
+      return;
+    }
+
+    if (av.userData.lives !== undefined && av.userData.lives <= 0) {
       const old = playerPathMeshes.get(id);
       if (old) {
         scene.remove(old);


### PR DESCRIPTION
## Summary
- avoid generating player path strips when local user is a spectator or has no lives
- skip path strips to remote players with zero lives

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856e48927c48326a43ce5aaf811b501