### PR TITLE
Replace numeric lives with visual life bars

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -188,8 +188,13 @@ function updateHealthBar() {
 function updateLivesDisplay() {
   const el = document.getElementById('life-count');
   if (el) {
-    el.textContent = myLives;
+    el.innerHTML = '';
     el.style.color = myColor.getStyle();
+    for (let i = 0; i < myLives; i++) {
+      const bar = document.createElement('span');
+      bar.className = 'life-bar';
+      el.appendChild(bar);
+    }
   }
 }
 let   character, bodyMesh, headMesh, Larm, Rarm, Lleg, Rleg;
@@ -1147,8 +1152,14 @@ function updateRemoteLabels() {
       return;
     }
     label.style.display = 'block';
-    label.textContent = av.userData.lives ?? START_LIVES;
+    const lives = av.userData.lives ?? START_LIVES;
+    label.innerHTML = '';
     label.style.color = av.userData.mat.color.getStyle();
+    for (let i = 0; i < lives; i++) {
+      const bar = document.createElement('span');
+      bar.className = 'life-bar';
+      label.appendChild(bar);
+    }
     const pos = av.userData.head.getWorldPosition(new THREE.Vector3());
     pos.project(camera);
     const x = (pos.x * 0.5 + 0.5) * innerWidth;

--- a/styles/style.css
+++ b/styles/style.css
@@ -109,12 +109,22 @@ canvas {
 }
 #life-count {
   position: absolute;
-  top: -18px;
+  top: -22px;
   left: 0;
   width: 100%;
-  text-align: center;
-  font-family: monospace;
+  display: flex;
+  justify-content: center;
+  gap: 2px;
   pointer-events: none;
+}
+
+.life-bar {
+  display: inline-block;
+  width: 12px;
+  height: 6px;
+  background: currentColor;
+  border: 1px solid rgba(0,0,0,0.4);
+  border-radius: 2px;
 }
 #health-fill {
   height: 100%;
@@ -134,10 +144,10 @@ canvas {
 .player-label {
   position: absolute;
   color: white;
-  font-family: monospace;
-  font-size: 14px;
-  white-space: nowrap;
+  display: flex;
+  gap: 2px;
   transform: translate(-50%, -50%);
   pointer-events: none;
+  font-size: 0;
 }
 


### PR DESCRIPTION
## Summary
- show a row of life bars for local player health
- use the same life bar display for remote players
- update styles for life bar elements

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856e945d1e08326a125077d19cbda23