### PR TITLE
Improve HUD and stack powerups

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
 
   <div id="health-bar">
     <div id="life-count"></div>
+    <div id="health-text"></div>
     <div id="health-fill"></div>
   </div>
   <div id="powerup-msg"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -200,6 +200,8 @@ let   spectator   = false;
 function updateHealthBar() {
   const fill = document.getElementById('health-fill');
   if (fill) fill.style.width = `${myHealth}%`;
+  const text = document.getElementById('health-text');
+  if (text) text.textContent = Math.round(myHealth);
 }
 
 function updateLivesDisplay() {

--- a/server.js
+++ b/server.js
@@ -269,13 +269,13 @@ wss.on('connection', ws => {
               p.health = Math.min(MAX_HEALTH, p.health + 20);
               break;
             case 'double':
-              p.doubleShots = DOUBLE_SHOTS;
+              p.doubleShots = (p.doubleShots || 0) + DOUBLE_SHOTS;
               break;
             case 'shield':
-              p.shield = SHIELD_DURATION;
+              p.shield = (p.shield || 0) + SHIELD_DURATION;
               break;
             case 'speed':
-              p.speed = SPEED_DURATION;
+              p.speed = (p.speed || 0) + SPEED_DURATION;
               break;
           }
         }

--- a/styles/style.css
+++ b/styles/style.css
@@ -126,6 +126,19 @@ canvas {
   border: 1px solid rgba(0,0,0,0.4);
   border-radius: 2px;
 }
+#health-text {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-family: monospace;
+  pointer-events: none;
+}
 #health-fill {
   height: 100%;
   width: 100%;
@@ -134,7 +147,7 @@ canvas {
 
 #powerup-msg {
   position: absolute;
-  bottom: 40px;
+  bottom: 80px;
   left: 50%;
   transform: translateX(-50%);
   font-family: sans-serif;


### PR DESCRIPTION
## Summary
- show numeric health text on the health bar
- move power-up message higher
- accumulate power-up effects on pickup

## Testing
- `npm install`
- `node server.js` *(fails without kill when backgrounded, indicates server runs)*

------
https://chatgpt.com/codex/tasks/task_e_68570018fbb8832683a5d2499d64b1be