### PR TITLE
Add respawn and scoreboard with basic teams

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,10 @@
   <div id="shoot-button"></div>
 
   <div id="health-bar">
-    <div id="life-count"></div>
     <div id="health-text"></div>
     <div id="health-fill"></div>
   </div>
+  <div id="scoreboard"></div>
   <div id="powerup-msg"></div>
   <div id="labels"></div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -153,7 +153,6 @@ const HIT_PULL_RADIUS = 4.0;               // range for projectile attraction
 const SHIELD_DURATION = 10;
 const SPEED_DURATION  = 10;
 const DOUBLE_SHOTS    = 10;
-const START_LIVES     = 5;
 const LABEL_VIS_DISTANCE = 40;          // max distance to show remote labels
 const mapSeed         = '🌎';                 // constant → identical terrain
 const noiseSky        = new SimplexNoise(mapSeed + 'sky');
@@ -194,8 +193,10 @@ let powerupTimer = 0;
 let   myId        = null;
 let   myColor     = new THREE.Color(0x222222);
 let   myHealth    = MAX_HEALTH;
-let   myLives     = START_LIVES;
 let   spectator   = false;
+let   myTeam      = null;
+const teams       = new Map();
+const scoreboardEl= document.getElementById('scoreboard');
 
 function updateHealthBar() {
   const fill = document.getElementById('health-fill');
@@ -204,18 +205,7 @@ function updateHealthBar() {
   if (text) text.textContent = Math.round(myHealth);
 }
 
-function updateLivesDisplay() {
-  const el = document.getElementById('life-count');
-  if (el) {
-    el.innerHTML = '';
-    el.style.color = myColor.getStyle();
-    for (let i = 0; i < myLives; i++) {
-      const bar = document.createElement('span');
-      bar.className = 'life-bar';
-      el.appendChild(bar);
-    }
-  }
-}
+function updateLivesDisplay() {}
 
 function showPowerupMessage(type){
   const el = document.getElementById('powerup-msg');
@@ -332,8 +322,6 @@ socket.addEventListener('message', e => {
     case 'welcome':
       myId    = msg.id;
       myColor = new THREE.Color().setStyle(msg.color);
-      myLives = START_LIVES;
-      updateLivesDisplay();
 
       // Update avatar colors if we've already built the character
       if (bodyMesh) {
@@ -385,11 +373,18 @@ socket.addEventListener('message', e => {
         if (av.userData.label) av.userData.label.remove();
         ghosts.delete(msg.id);
       }
-      if (msg.id === myId) {
-        alert('Game over! You are now spectating.');
-        spectator = true;
-        if (character) scene.remove(character);
-      }
+    } break;
+
+    case 'teamRequest': {
+      const accept = confirm(`${msg.color} wants to team up. Accept?`);
+      socket.send(JSON.stringify({t:'teamResponse', requester: msg.from, accept}));
+    } break;
+    case 'teamJoin': {
+      // no action needed, snapshot will update team
+      alert(`Teamed up with ${msg.with}`);
+    } break;
+    case 'teamDeclined': {
+      alert(`${msg.from} declined your team request`);
     } break;
   }
 });
@@ -399,7 +394,6 @@ noise = new SimplexNoise(mapSeed);
 initTerrain().then(() => {
   initCharacter();
   updateHealthBar();
-  updateLivesDisplay();
   requestAnimationFrame(animate);
 });
 
@@ -642,7 +636,7 @@ function makeRemoteAvatar(col){
   root.add(hb);
   root.userData={ body,head,Larm,Rarm,Lleg,Rleg, mat,
     boxGeo, octGeo:new THREE.OctahedronGeometry(1,0).rotateX(Math.PI/2),
-    healthBar:hb };
+    healthBar:hb, colorName: col };
   scene.add(root);
   ensureRemoteHasLoadedBullet(root,col);
   return root;
@@ -676,10 +670,6 @@ function makeRemoteAvatar(col){
     powerups = pus;
   }
   if (pack[myId] && typeof pack[myId].health === 'number') {
-    if (typeof pack[myId].lives === 'number') {
-      myLives = pack[myId].lives;
-      updateLivesDisplay();
-    }
     const newH = pack[myId].health;
     if(newH < prevMyHealth && bodyMesh){
       flashMaterial(bodyMesh.material);
@@ -696,11 +686,14 @@ function makeRemoteAvatar(col){
     shieldTimer = pack[myId].shield || 0;
     speedTimer  = pack[myId].speed  || 0;
     doubleShotsLeft = pack[myId].double || 0;
+    myTeam = pack[myId].team || null;
+    teams.set(myId, myTeam);
   }
 
   /* ---------- players ---------- */
   for(const [id,st] of Object.entries(pack)){
     if(id===myId) continue;
+    teams.set(id, st.team || null);
     const av=ghosts.get(id) ?? makeRemoteAvatar(st.color);
     ghosts.set(id,av);
     av.position.set(st.x,st.y,st.z);
@@ -790,6 +783,7 @@ function makeRemoteAvatar(col){
   });
   updatePlayerPathMeshes();
   updateRemoteLabels();
+  updateScoreboard(pack);
 }
 
 /* ────────────────────────── INPUT HANDLERS ───────────────────────── */
@@ -837,6 +831,19 @@ document.addEventListener('keyup',e=>{
       break;
     case'Space':spaceHeld=false;break;
     case'KeyZ':case'KeyZ':zHeld =false;break;
+  }
+});
+
+renderer.domElement.addEventListener('contextmenu', e => {
+  e.preventDefault();
+  if(!character) return;
+  let closestId=null; let best=Infinity;
+  ghosts.forEach((av,id)=>{
+    const d=av.position.distanceTo(character.position);
+    if(d<3&&d<best){best=d; closestId=id;}
+  });
+  if(closestId){
+    socket.send(JSON.stringify({t:'teamRequest', target:closestId}));
   }
 });
 
@@ -894,6 +901,7 @@ function animate(now){
     if(p.owner===myId){
       ghosts.forEach((av,id)=>{
         if(hitPlayer) return;
+        if(teams.get(id)&&teams.get(id)===myTeam) return;
         if(avatarHitTest(av, prevPos, p.mesh.position)){
           socket.send(JSON.stringify({t:'hitPlayer', target:id, shotId:p.id}));
           flashMaterial(av.userData.mat);
@@ -1137,7 +1145,7 @@ function createPathStrip(from, to, startWidth = 1, endWidth = 0.5,
 
 function updatePlayerPathMeshes() {
   if (!terrain || !character || !bodyMesh) return;
-  if (spectator || myLives <= 0) {
+  if (spectator) {
     playerPathMeshes.forEach(mesh => {
       scene.remove(mesh);
       mesh.geometry.dispose();
@@ -1158,16 +1166,7 @@ function updatePlayerPathMeshes() {
       return;
     }
 
-    if (av.userData.lives !== undefined && av.userData.lives <= 0) {
-      const old = playerPathMeshes.get(id);
-      if (old) {
-        scene.remove(old);
-        old.geometry.dispose();
-        old.material.dispose();
-        playerPathMeshes.delete(id);
-      }
-      return;
-    }
+
 
     const start = bodyMesh.getWorldPosition(new THREE.Vector3());
     const end = av.userData.body.getWorldPosition(new THREE.Vector3());
@@ -1230,18 +1229,25 @@ function updateRemoteLabels() {
       return;
     }
     label.style.display = 'block';
-    const lives = av.userData.lives ?? START_LIVES;
-    label.innerHTML = '';
+    label.textContent = av.userData.colorName || '';
     label.style.color = av.userData.mat.color.getStyle();
-    for (let i = 0; i < lives; i++) {
-      const bar = document.createElement('span');
-      bar.className = 'life-bar';
-      label.appendChild(bar);
-    }
     const x = (pos.x * 0.5 + 0.5) * innerWidth;
     const y = (-pos.y * 0.5 + 0.5) * innerHeight - 40;
     label.style.transform = `translate(-50%, -50%) translate(${x}px,${y}px)`;
   });
+}
+
+function updateScoreboard(snapshotPlayers){
+  if(!scoreboardEl) return;
+  const entries = Object.values(snapshotPlayers).map(p=>({
+    color:p.color,
+    kills:p.kills||0,
+    deaths:p.deaths||0,
+    team:p.team||null
+  })).sort((a,b)=>b.kills-a.kills);
+  scoreboardEl.innerHTML = entries.map(e =>
+    `<div style="color:${e.color}">${e.color}: ${e.kills}/${e.deaths}</div>`
+  ).join('');
 }
 
 function spawnTerrainSpike(x,z,r,delay,height=1){

--- a/server.js
+++ b/server.js
@@ -41,7 +41,6 @@ const POWERUP_COUNTS = {
 const SHIELD_DURATION = 10; // seconds
 const SPEED_DURATION  = 10; // seconds
 const DOUBLE_SHOTS    = 10; // number of double shots
-const START_LIVES     = 5;  // lives per player
 
 /* ────────────────── GLOBAL STATE ──────────────────────── */
 // WebSocket server instance
@@ -89,7 +88,9 @@ function packSnapshot() {
           shield: p.shield || 0,
           speed: p.speed || 0,
           double: p.doubleShots || 0,
-          lives: p.lives
+          kills: p.kills || 0,
+          deaths: p.deaths || 0,
+          team: p.team
         }
       ])
     ),
@@ -137,16 +138,9 @@ function applySpikeDamage(spikes){
           if(p.shield>0) break;
           p.health=Math.max(0,p.health-TERRAIN_DAMAGE);
           if(p.health<=0){
-            p.lives -= 1;
-            if(p.lives>0){
-              wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id})));
-              p.health=MAX_HEALTH;
-            } else {
-              wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerOut',id})));
-              usedColors.delete(p.color);
-              players.delete(id);
-              break;
-            }
+            p.deaths += 1;
+            wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id})));
+            p.health=MAX_HEALTH;
           }
           break;
         }
@@ -197,6 +191,7 @@ wss.on('connection', ws => {
 
   // Initialize player state
   players.set(id, {
+    socket: ws,
     input:{},
     state:{},
     color,
@@ -204,7 +199,9 @@ wss.on('connection', ws => {
     shield: 0,
     speed: 0,
     doubleShots: 0,
-    lives: START_LIVES
+    kills: 0,
+    deaths: 0,
+    team: null
   });
 
   // Send welcome packet with assigned ID, color, and noise seed
@@ -285,8 +282,10 @@ wss.on('connection', ws => {
       case 'hitPlayer': {
         if (!players.has(id)) break;
         const target = players.get(msg.target);
-        if (target) {
+        const attacker = players.get(id);
+        if (target && attacker) {
           if (target.shield > 0) break;
+          if (attacker.team && target.team && attacker.team === target.team) break;
           const idx = projectiles.findIndex(p => p.id===msg.shotId);
           let mult = 1;
           if (idx !== -1) {
@@ -297,17 +296,36 @@ wss.on('connection', ws => {
           const dmg = PROJECTILE_DAMAGE * mult;
           target.health = Math.max(0, target.health - dmg);
           if (target.health <= 0) {
-            target.lives -= 1;
-            if (target.lives > 0) {
-              wss.clients.forEach(c => c.readyState===1 &&
-                c.send(JSON.stringify({ t:'playerDied', id: msg.target })));
-              target.health = MAX_HEALTH;
-            } else {
-              wss.clients.forEach(c => c.readyState===1 &&
-                c.send(JSON.stringify({ t:'playerOut', id: msg.target })));
-              usedColors.delete(target.color);
-              players.delete(msg.target);
-            }
+            attacker.kills += 1;
+            target.deaths += 1;
+            wss.clients.forEach(c => c.readyState===1 &&
+              c.send(JSON.stringify({ t:'playerDied', id: msg.target })));
+            target.health = MAX_HEALTH;
+          }
+        }
+        break;
+      }
+
+      case 'teamRequest': {
+        const target = players.get(msg.target);
+        if (target) {
+          target.socket.send(JSON.stringify({ t:'teamRequest', from:id, color: players.get(id).color }));
+        }
+        break;
+      }
+
+      case 'teamResponse': {
+        const requester = players.get(msg.requester);
+        const responder = players.get(id);
+        if (requester && responder) {
+          if (msg.accept) {
+            const teamId = requester.team || responder.team || requester.color;
+            requester.team = teamId;
+            responder.team = teamId;
+            requester.socket.send(JSON.stringify({ t:'teamJoin', with: responder.color }));
+            responder.socket.send(JSON.stringify({ t:'teamJoin', with: requester.color }));
+          } else {
+            requester.socket.send(JSON.stringify({ t:'teamDeclined', from: responder.color }));
           }
         }
         break;

--- a/styles/style.css
+++ b/styles/style.css
@@ -107,25 +107,6 @@ canvas {
   border-radius: 4px;
   z-index: 12;
 }
-#life-count {
-  position: absolute;
-  top: -22px;
-  left: 0;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  gap: 2px;
-  pointer-events: none;
-}
-
-.life-bar {
-  display: inline-block;
-  width: 12px;
-  height: 6px;
-  background: currentColor;
-  border: 1px solid rgba(0,0,0,0.4);
-  border-radius: 2px;
-}
 #health-text {
   position: absolute;
   top: 0;
@@ -182,5 +163,17 @@ canvas {
   transform: translate(-50%, -50%);
   pointer-events: none;
   font-size: 0;
+}
+
+#scoreboard {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(0,0,0,0.5);
+  padding: 4px 8px;
+  font-family: monospace;
+  font-size: 14px;
+  color: white;
+  z-index: 20;
 }
 


### PR DESCRIPTION
## Summary
- players no longer enter spectator mode when health drops to zero
- track kills and deaths and show a scoreboard
- players can right-click near someone to request a team up
- teammates cannot damage each other
- update HTML/CSS for scoreboard UI

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68570737f53083269ee7d2745a739f0a