### PR TITLE
Improve leaderboard UI

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1245,9 +1245,18 @@ function updateScoreboard(snapshotPlayers){
     deaths:p.deaths||0,
     team:p.team||null
   })).sort((a,b)=>b.kills-a.kills);
-  scoreboardEl.innerHTML = entries.map(e =>
-    `<div style="color:${e.color}">${e.color}: ${e.kills}/${e.deaths}</div>`
+  const rows = entries.map(e =>
+    `<tr style="color:${e.color}">`+
+      `<td class="name">${e.color}</td>`+
+      `<td class="kills">${e.kills}</td>`+
+      `<td class="deaths">${e.deaths}</td>`+
+    `</tr>`
   ).join('');
+  scoreboardEl.innerHTML =
+    `<table>`+
+      `<tr><th>Player</th><th>K</th><th>D</th></tr>`+
+      rows+
+    `</table>`;
 }
 
 function spawnTerrainSpike(x,z,r,delay,height=1){

--- a/styles/style.css
+++ b/styles/style.css
@@ -175,5 +175,20 @@ canvas {
   font-size: 14px;
   color: white;
   z-index: 20;
+  border-radius: 4px;
+}
+
+#scoreboard table {
+  border-collapse: collapse;
+}
+
+#scoreboard th,
+#scoreboard td {
+  padding: 2px 6px;
+}
+
+#scoreboard th {
+  text-align: left;
+  border-bottom: 1px solid #fff;
 }
 


### PR DESCRIPTION
## Summary
- style scoreboard with a table
- show player, kill, and death columns

## Testing
- `node -c js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68570cbd3a3083269042b0449a301580