### PR TITLE
Use F key for teaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ want to trade visual quality for higher frame rates.
 - Spikes would normally erupt from the ground before dealing damage so alert players can dodge.
 - Characters briefly flash red when hurt so you can tell a hit landed.
 - Boomerang shots now register hits when striking any limb, not just the torso.
+- Press **F** while near another player to request teaming. If they also press
+  **F** within a couple of seconds, you will join the same team.

--- a/js/main.js
+++ b/js/main.js
@@ -375,16 +375,9 @@ socket.addEventListener('message', e => {
       }
     } break;
 
-    case 'teamRequest': {
-      const accept = confirm(`${msg.color} wants to team up. Accept?`);
-      socket.send(JSON.stringify({t:'teamResponse', requester: msg.from, accept}));
-    } break;
     case 'teamJoin': {
       // no action needed, snapshot will update team
       alert(`Teamed up with ${msg.with}`);
-    } break;
-    case 'teamDeclined': {
-      alert(`${msg.from} declined your team request`);
     } break;
   }
 });
@@ -818,6 +811,9 @@ document.addEventListener('keydown',e=>{
       zHeld =true;
       if(flyMode&&now-lastZ<300) flyMode=false;
       lastZ=now; break;
+    case'KeyF':
+      attemptTeam();
+      break;
     case'Escape':teleport();break;
   }
 });
@@ -834,8 +830,7 @@ document.addEventListener('keyup',e=>{
   }
 });
 
-renderer.domElement.addEventListener('contextmenu', e => {
-  e.preventDefault();
+function attemptTeam(){
   if(!character) return;
   let closestId=null; let best=Infinity;
   ghosts.forEach((av,id)=>{
@@ -845,7 +840,9 @@ renderer.domElement.addEventListener('contextmenu', e => {
   if(closestId){
     socket.send(JSON.stringify({t:'teamRequest', target:closestId}));
   }
-});
+}
+
+
 
 /* ───────────────────────────── GAME LOOP ─────────────────────────── */
 let lastFrame=0;

--- a/server.js
+++ b/server.js
@@ -53,6 +53,9 @@ const projectiles = [];
 let nextShotId = 0;
 // Power-ups present in the world
 let powerups = [];
+// Pending team requests: id -> Map(targetId -> timestamp)
+const pendingTeam = new Map();
+const TEAM_REQ_WINDOW_MS = 2000;
 
 /* ──────────── NAMED COLOR PALETTE ────────────────────── */
 // A set of high-contrast color names
@@ -308,24 +311,27 @@ wss.on('connection', ws => {
 
       case 'teamRequest': {
         const target = players.get(msg.target);
-        if (target) {
-          target.socket.send(JSON.stringify({ t:'teamRequest', from:id, color: players.get(id).color }));
-        }
-        break;
-      }
+        const requester = players.get(id);
+        if (target && requester) {
+          const dx = (requester.state.x||0) - (target.state.x||0);
+          const dz = (requester.state.z||0) - (target.state.z||0);
+          if (Math.hypot(dx, dz) <= 3) {
+            const now = Date.now();
+            let map = pendingTeam.get(id);
+            if (!map) { map = new Map(); pendingTeam.set(id, map); }
+            map.set(msg.target, now);
 
-      case 'teamResponse': {
-        const requester = players.get(msg.requester);
-        const responder = players.get(id);
-        if (requester && responder) {
-          if (msg.accept) {
-            const teamId = requester.team || responder.team || requester.color;
-            requester.team = teamId;
-            responder.team = teamId;
-            requester.socket.send(JSON.stringify({ t:'teamJoin', with: responder.color }));
-            responder.socket.send(JSON.stringify({ t:'teamJoin', with: requester.color }));
-          } else {
-            requester.socket.send(JSON.stringify({ t:'teamDeclined', from: responder.color }));
+            const tMap = pendingTeam.get(msg.target);
+            const tTime = tMap && tMap.get(id);
+            if (tTime && now - tTime <= TEAM_REQ_WINDOW_MS) {
+              const teamId = requester.team || target.team || requester.color;
+              requester.team = teamId;
+              target.team = teamId;
+              requester.socket.send(JSON.stringify({ t:'teamJoin', with: target.color }));
+              target.socket.send(JSON.stringify({ t:'teamJoin', with: requester.color }));
+              map.delete(msg.target);
+              if (tMap) tMap.delete(id);
+            }
           }
         }
         break;


### PR DESCRIPTION
## Summary
- use **F** key instead of right click to request a team
- form teams automatically when both players press **F** nearby
- document new control in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68570dd442d083268150d53688cfb2c5