### PR TITLE
Improve leaderboard UI

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -354,8 +354,13 @@ socket.addEventListener('message', e => {
 
     case 'playerDied': {
       if (msg.id === myId) {
-        teleport();
+        teleport(msg.x, msg.z);
       } else {
+        const av = ghosts.get(msg.id);
+        if(av && msg.x!==undefined && msg.z!==undefined){
+          const y = meshHeightAt(msg.x,msg.z)+1;
+          av.position.set(msg.x,y,msg.z);
+        }
         const mesh = playerPathMeshes.get(msg.id);
         if (mesh) {
           scene.remove(mesh);
@@ -594,8 +599,11 @@ function recallProjectile(){
     if(p.id===undefined) p.returning = true;
   }
 }
-function teleport(){
-  const x=(Math.random()-0.5)*GRID*SPAN, z=(Math.random()-0.5)*GRID*SPAN;
+function teleport(x=null,z=null){
+  if(x===null||z===null){
+    x=(Math.random()-0.5)*GRID*SPAN;
+    z=(Math.random()-0.5)*GRID*SPAN;
+  }
   const y=meshHeightAt(x,z)+1;
   character.position.set(x,y,z);
   vertVel=0; onGround=true;
@@ -1245,9 +1253,18 @@ function updateScoreboard(snapshotPlayers){
     deaths:p.deaths||0,
     team:p.team||null
   })).sort((a,b)=>b.kills-a.kills);
-  scoreboardEl.innerHTML = entries.map(e =>
-    `<div style="color:${e.color}">${e.color}: ${e.kills}/${e.deaths}</div>`
+  const rows = entries.map(e =>
+    `<tr style="color:${e.color}">`+
+      `<td class="name">${e.color}</td>`+
+      `<td class="kills">${e.kills}</td>`+
+      `<td class="deaths">${e.deaths}</td>`+
+    `</tr>`
   ).join('');
+  scoreboardEl.innerHTML =
+    `<table>`+
+      `<tr><th>Player</th><th>K</th><th>D</th></tr>`+
+      rows+
+    `</table>`;
 }
 
 function spawnTerrainSpike(x,z,r,delay,height=1){

--- a/server.js
+++ b/server.js
@@ -127,6 +127,15 @@ function sendSpike(x, z, h){
   wss.clients.forEach(c => c.readyState === 1 && c.send(msg));
 }
 
+function respawnPlayer(id){
+  const p = players.get(id);
+  if(!p) return {x:0,z:0};
+  const x = (Math.random()*2-1)*TERRAIN_HALF;
+  const z = (Math.random()*2-1)*TERRAIN_HALF;
+  p.state = { ...(p.state||{}), x, y:0, z };
+  return {x,z};
+}
+
 function applySpikeDamage(spikes){
   setTimeout(() => {
     for(const [id,p] of players){
@@ -139,7 +148,8 @@ function applySpikeDamage(spikes){
           p.health=Math.max(0,p.health-TERRAIN_DAMAGE);
           if(p.health<=0){
             p.deaths += 1;
-            wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id})));
+            const spawn = respawnPlayer(id);
+            wss.clients.forEach(c=>c.readyState===1&&c.send(JSON.stringify({t:'playerDied',id,x:spawn.x,z:spawn.z})));
             p.health=MAX_HEALTH;
           }
           break;
@@ -298,8 +308,9 @@ wss.on('connection', ws => {
           if (target.health <= 0) {
             attacker.kills += 1;
             target.deaths += 1;
+            const spawn = respawnPlayer(msg.target);
             wss.clients.forEach(c => c.readyState===1 &&
-              c.send(JSON.stringify({ t:'playerDied', id: msg.target })));
+              c.send(JSON.stringify({ t:'playerDied', id: msg.target, x: spawn.x, z: spawn.z })));
             target.health = MAX_HEALTH;
           }
         }

--- a/styles/style.css
+++ b/styles/style.css
@@ -175,5 +175,20 @@ canvas {
   font-size: 14px;
   color: white;
   z-index: 20;
+  border-radius: 4px;
+}
+
+#scoreboard table {
+  border-collapse: collapse;
+}
+
+#scoreboard th,
+#scoreboard td {
+  padding: 2px 6px;
+}
+
+#scoreboard th {
+  text-align: left;
+  border-bottom: 1px solid #fff;
 }
 


### PR DESCRIPTION
## Summary
- style scoreboard with a table
- show player, kill, and death columns
- respawn players at random positions when they die

## Testing
- `node --check js/main.js`
- `node --check server.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68570cbd3a3083269042b0449a301580