### PR TITLE
Add numbered teams and request effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ want to trade visual quality for higher frame rates.
 - Boomerang shots now register hits when striking any limb, not just the torso.
 - Press **F** while near another player to request teaming. If they also press
   **F** within a couple of seconds, you will join the same team.
+  Teams are numbered sequentially, starting at 1, and a short effect plays when
+  a request is sent and when a team is formed.

--- a/js/main.js
+++ b/js/main.js
@@ -381,8 +381,14 @@ socket.addEventListener('message', e => {
     } break;
 
     case 'teamJoin': {
-      // no action needed, snapshot will update team
-      alert(`Teamed up with ${msg.with}`);
+      // snapshot will update team; show a confirmation effect
+      let pos = character ? character.position.clone() : new THREE.Vector3();
+      ghosts.forEach(av=>{
+        if(av.userData.colorName===msg.with){
+          pos = av.position.clone().add(pos).multiplyScalar(0.5);
+        }
+      });
+      spawnTeamConfirmEffect(pos);
     } break;
   }
 });
@@ -847,6 +853,11 @@ function attemptTeam(){
   });
   if(closestId){
     socket.send(JSON.stringify({t:'teamRequest', target:closestId}));
+    const av = ghosts.get(closestId);
+    if(av){
+      const mid = av.position.clone().add(character.position).multiplyScalar(0.5);
+      spawnTeamRequestEffect(mid);
+    }
   }
 }
 
@@ -981,8 +992,9 @@ function animate(now){
       scene.remove(e.mesh); e.mesh.geometry.dispose(); e.mesh.material.dispose();
       hitEffects.splice(i,1);
     }else{
-      e.mesh.material.opacity=e.time/0.3;
-      e.mesh.scale.setScalar(1+(0.3-e.time));
+      const prog = 1 - e.time / e.total;
+      e.mesh.material.opacity = e.time / e.total;
+      e.mesh.scale.setScalar(1 + prog);
     }
   }
 
@@ -1288,13 +1300,21 @@ function spawnTerrainSpike(x,z,r,delay,height=1){
   spikes.push({ x, z, r, delay, age:0, height, disc, spike });
 }
 
-function spawnHitEffect(pos){
+function spawnHitEffect(pos, color=0xff0000, duration=0.3){
   const g = new THREE.SphereGeometry(0.3,8,8);
-  const m = new THREE.MeshBasicMaterial({ color:0xff0000, transparent:true });
+  const m = new THREE.MeshBasicMaterial({ color, transparent:true });
   const mesh = new THREE.Mesh(g,m);
   mesh.position.copy(pos);
   scene.add(mesh);
-  hitEffects.push({ mesh, time:0.3 });
+  hitEffects.push({ mesh, time:duration, total:duration });
+}
+
+function spawnTeamRequestEffect(pos){
+  spawnHitEffect(pos, 0x0000ff, 0.5);
+}
+
+function spawnTeamConfirmEffect(pos){
+  spawnHitEffect(pos, 0x00ff00, 0.7);
 }
 
 function flashMaterial(mat){

--- a/server.js
+++ b/server.js
@@ -56,6 +56,7 @@ let powerups = [];
 // Pending team requests: id -> Map(targetId -> timestamp)
 const pendingTeam = new Map();
 const TEAM_REQ_WINDOW_MS = 2000;
+let nextTeamNumber = 1; // sequential team ids
 
 /* ──────────── NAMED COLOR PALETTE ────────────────────── */
 // A set of high-contrast color names
@@ -335,11 +336,11 @@ wss.on('connection', ws => {
             const tMap = pendingTeam.get(msg.target);
             const tTime = tMap && tMap.get(id);
             if (tTime && now - tTime <= TEAM_REQ_WINDOW_MS) {
-              const teamId = requester.team || target.team || requester.color;
+              const teamId = requester.team || target.team || nextTeamNumber++;
               requester.team = teamId;
               target.team = teamId;
-              requester.socket.send(JSON.stringify({ t:'teamJoin', with: target.color }));
-              target.socket.send(JSON.stringify({ t:'teamJoin', with: requester.color }));
+              requester.socket.send(JSON.stringify({ t:'teamJoin', with: target.color, team: teamId }));
+              target.socket.send(JSON.stringify({ t:'teamJoin', with: requester.color, team: teamId }));
               map.delete(msg.target);
               if (tMap) tMap.delete(id);
             }


### PR DESCRIPTION
## Summary
- assign sequential IDs to teams on the server
- show colored effects when sending or confirming a team request
- allow team join messages to include the new ID
- document new behavior in README

## Testing
- `node --check server.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_685714518e888326a226b90f4f4d07ee